### PR TITLE
Fix path to futur.ttf

### DIFF
--- a/fonts/fonts.font
+++ b/fonts/fonts.font
@@ -14,7 +14,7 @@ fontfiles = {
 			"l_turkish"
 		}
 		files = {
-			"fonts/CWE/futura/futur.ttf"
+			"fonts/cwe/futura/futur.ttf"
 			"fonts/NotoSans/NotoSansJP-Regular.otf"
 			"fonts/NotoSans/NotoSansKR-Regular.otf"
 			"fonts/NotoSans/NotoSansSC-Regular.otf"
@@ -74,7 +74,7 @@ fontfiles = {
 			"l_turkish"
 		}
 		files = {
-			"fonts/CWE/futura/futura_bold.ttf"
+			"fonts/cwe/futura/futura_bold.ttf"
 			"fonts/NotoSans/NotoSansJP-Regular.otf"
 			"fonts/NotoSans/NotoSansKR-Regular.otf"
 			"fonts/NotoSans/NotoSansSC-Regular.otf"
@@ -134,7 +134,7 @@ fontfiles = {
 			"l_turkish"
 		}
 		files = {
-			"fonts/CWE/futura/futura_bold_italic.ttf"
+			"fonts/cwe/futura/futura_bold_italic.ttf"
 			"fonts/NotoSans/NotoSansJP-Regular.otf"
 			"fonts/NotoSans/NotoSansKR-Regular.otf"
 			"fonts/NotoSans/NotoSansSC-Regular.otf"
@@ -194,7 +194,7 @@ fontfiles = {
 			"l_turkish"
 		}
 		files = {
-			"fonts/CWE/futura/futura_italic.ttf"
+			"fonts/cwe/futura/futura_italic.ttf"
 			"fonts/NotoSans/NotoSansJP-Regular.otf"
 			"fonts/NotoSans/NotoSansKR-Regular.otf"
 			"fonts/NotoSans/NotoSansSC-Regular.otf"
@@ -254,7 +254,7 @@ fontfiles = {
 			"l_turkish"
 		}
 		files = {
-			"fonts/CWE/BebasNeue.ttf"
+			"fonts/cwe/BebasNeue.ttf"
 			"fonts/NotoSans/NotoSansJP-Regular.otf"
 			"fonts/NotoSans/NotoSansKR-Regular.otf"
 			"fonts/NotoSans/NotoSansSC-Regular.otf"
@@ -314,7 +314,7 @@ fontfiles = {
 			"l_turkish"
 		}
 		files = {
-			"fonts/CWE/Cabin-Regular.ttf"
+			"fonts/cwe/Cabin-Regular.ttf"
 			"fonts/NotoSans/NotoSansJP-Regular.otf"
 			"fonts/NotoSans/NotoSansKR-Regular.otf"
 			"fonts/NotoSans/NotoSansSC-Regular.otf"
@@ -374,7 +374,7 @@ fontfiles = {
 			"l_turkish"
 		}
 		files = {
-			"fonts/CWE/Cabin-Bold.ttf"
+			"fonts/cwe/Cabin-Bold.ttf"
 			"fonts/NotoSans/NotoSansJP-Regular.otf"
 			"fonts/NotoSans/NotoSansKR-Regular.otf"
 			"fonts/NotoSans/NotoSansSC-Regular.otf"
@@ -434,7 +434,7 @@ fontfiles = {
 			"l_turkish"
 		}
 		files = {
-			"fonts/CWE/Cabin-Italic.ttf"
+			"fonts/cwe/Cabin-Italic.ttf"
 			"fonts/NotoSans/NotoSansJP-Regular.otf"
 			"fonts/NotoSans/NotoSansKR-Regular.otf"
 			"fonts/NotoSans/NotoSansSC-Regular.otf"
@@ -494,7 +494,7 @@ fontfiles = {
 			"l_turkish"
 		}
 		files = {
-			"fonts/CWE/Cabin-BoldItalic.ttf"
+			"fonts/cwe/Cabin-BoldItalic.ttf"
 			"fonts/NotoSans/NotoSansJP-Regular.otf"
 			"fonts/NotoSans/NotoSansKR-Regular.otf"
 			"fonts/NotoSans/NotoSansSC-Regular.otf"


### PR DESCRIPTION
Linux, and optionally macOS, has a case sensitive filesystem, meaning the game was looking for the font file in the wrong directory.

This fixes the config, so it points to the lowercase directory name.