### PR TITLE
fix: spelling errors

### DIFF
--- a/common/production_methods/03_mines.txt
+++ b/common/production_methods/03_mines.txt
@@ -66,7 +66,7 @@ pm_colossal_machinery_extraction_coal = {
 	texture = "gfx/interface/icons/generic_icons/unused/lack.dds"
 	pollution_generation = 15
 	unlocking_technologies = {
-		traverse_engine
+		transverse_engine
 	}
 	building_modifiers = {
 		workforce_scaled = {
@@ -302,7 +302,7 @@ pm_colossal_machinery_extraction_iron = {
 	texture = "gfx/interface/icons/generic_icons/unused/lack.dds"
 	pollution_generation = 15
 	unlocking_technologies = {
-		traverse_engine
+		transverse_engine
 	}
 	building_modifiers = {
 		workforce_scaled = {
@@ -538,7 +538,7 @@ pm_colossal_machinery_extraction_copper = {
 	texture = "gfx/interface/icons/generic_icons/unused/lack.dds"
 	pollution_generation = 15
 	unlocking_technologies = {
-		traverse_engine
+		transverse_engine
 	}
 	building_modifiers = {
 		workforce_scaled = {
@@ -774,7 +774,7 @@ pm_colossal_machinery_extraction_rare_earth_elements = {
 	texture = "gfx/interface/icons/generic_icons/unused/lack.dds"
 	pollution_generation = 15
 	unlocking_technologies = {
-		traverse_engine
+		transverse_engine
 	}
 	building_modifiers = {
 		workforce_scaled = {
@@ -1010,7 +1010,7 @@ pm_colossal_machinery_extraction_bauxite = {
 	texture = "gfx/interface/icons/generic_icons/unused/lack.dds"
 	pollution_generation = 15
 	unlocking_technologies = {
-		traverse_engine
+		transverse_engine
 	}
 	building_modifiers = {
 		workforce_scaled = {
@@ -1246,7 +1246,7 @@ pm_colossal_machinery_extraction_uranium = {
 	texture = "gfx/interface/icons/generic_icons/unused/lack.dds"
 	pollution_generation = 15
 	unlocking_technologies = {
-		traverse_engine
+		transverse_engine
 	}
 	building_modifiers = {
 		workforce_scaled = {
@@ -1482,7 +1482,7 @@ pm_colossal_machinery_extraction_lead = {
 	texture = "gfx/interface/icons/generic_icons/unused/lack.dds"
 	pollution_generation = 15
 	unlocking_technologies = {
-		traverse_engine
+		transverse_engine
 	}
 	building_modifiers = {
 		workforce_scaled = {
@@ -1717,7 +1717,7 @@ pm_colossal_machinery_extraction_phosphorus = {
 	texture = "gfx/interface/icons/generic_icons/unused/lack.dds"
 	pollution_generation = 15
 	unlocking_technologies = {
-		traverse_engine
+		transverse_engine
 	}
 	building_modifiers = {
 		workforce_scaled = {
@@ -1968,7 +1968,7 @@ pm_colossal_machinery_extraction_gold = {
 	texture = "gfx/interface/icons/generic_icons/unused/lack.dds"
 	pollution_generation = 15
 	unlocking_technologies = {
-		traverse_engine
+		transverse_engine
 	}
 	building_modifiers = {
 		workforce_scaled = {


### PR DESCRIPTION
"traverse_engine" is now corrected to "transverse_engine"