### PR TITLE
warsaw pact event issue resolve

### DIFF
--- a/events/warsaw_pact_events/warsaw_pact_formation.txt
+++ b/events/warsaw_pact_events/warsaw_pact_formation.txt
@@ -28,25 +28,25 @@ warsaw_pact_formation.1 = {
 	option = { # Sends delegations to potential members
 		name = warsaw_pact_formation.1.a
 		highlighted_option = yes
-		c:ALB = {
+		c:ALB ?= {
 			trigger_event = warsaw_pact_formation.2
 		}
-		c:POL = {
+		c:POL ?= {
 			trigger_event = warsaw_pact_formation.2
 		}
-		c:CZH = {
+		c:CZH ?= {
 			trigger_event = warsaw_pact_formation.2
 		}
-		c:HUN = {
+		c:HUN ?= {
 			trigger_event = warsaw_pact_formation.2
 		}
-		c:BUL = {
+		c:BUL ?= {
 			trigger_event = warsaw_pact_formation.2
 		}
-		c:ROM = {
+		c:ROM ?= {
 			trigger_event = warsaw_pact_formation.2
 		}
-		c:DDR = {
+		c:DDR ?= {
 			trigger_event = warsaw_pact_formation.2
 		}
 		c:RUS = {


### PR DESCRIPTION
fixes an issue where if a nation didn't exist the warsaw pact formation.1 event crashed the game.

Adds existence checks to each of the countries getting the initial event. 