### PR TITLE
Monetary policy automation

### DIFF
--- a/common/decisions/bretton_woods.txt
+++ b/common/decisions/bretton_woods.txt
@@ -122,22 +122,15 @@ end_bretton_woods_agreement = {
 		}
 		modifier = {
 			trigger = {
-				this = {
-					inflation_value >= 30
-				}
+				scaled_debt > 0.25
 			}
-			add = 20
+			add = 50
 		}
 		modifier = {
 			trigger = {
-				this = {
-					or = {
-						money_supply_percentage >= 30
-						money_supply_percentage <= -30
-					}
-				}
+				has_healthy_economy = no
 			}
-			add = 20
+			add = 50
 		}
 	}
 }

--- a/common/decisions/bretton_woods.txt
+++ b/common/decisions/bretton_woods.txt
@@ -70,7 +70,7 @@ leave_bretton_woods_agreement = {
 		base = -10
 		modifier = {
 			trigger = {
-				year >= 1970
+				game_date > 1970.1.1
 			}
 			add = 50
 		}
@@ -116,7 +116,7 @@ end_bretton_woods_agreement = {
 		base = -50
 		modifier = {
 			trigger = {
-				year >= 1970
+				game_date > 1970.1.1
 			}
 			add = 50
 		}

--- a/common/decisions/china_decisions.txt
+++ b/common/decisions/china_decisions.txt
@@ -64,7 +64,7 @@
 		base = -100
 		modifier = {
 			trigger = {
-				year >= 1952
+				game_date > 1952.1.1
 			}
 			add = 200
 		}

--- a/common/flag_definitions/00_flag_definitions_CWP.txt
+++ b/common/flag_definitions/00_flag_definitions_CWP.txt
@@ -1692,7 +1692,7 @@ HUN = { # Hungary
 		priority = 1501
 		trigger = {
 			coa_def_communist_flag_trigger = yes
-			year >= 1957
+			game_date > 1957.1.1
 		}
 	}
 }
@@ -2568,7 +2568,7 @@ OMA = { # Oman
 		coa_with_overlord_canton = OMA_subject
 		priority = 2
 		trigger = {
-			year >= 1970
+			game_date > 1970.1.1
 		}
 	}
 	flag_definition = {
@@ -2748,7 +2748,7 @@ ROM = { # Romania
 		priority = 1501
 		trigger = {
 			coa_def_communist_flag_trigger = yes
-			year >= 1948
+			game_date > 1948.1.1
 		}
 	}
 }
@@ -3559,7 +3559,7 @@ MAU = {
 		subject_canton = MAU_modern
 		priority = 2
 		trigger = {
-			year >= 2017
+			game_date > 2017.1.1
 		}
 	}
 	flag_definition = {

--- a/common/game_rules/cwp_game_rules.txt
+++ b/common/game_rules/cwp_game_rules.txt
@@ -1,4 +1,11 @@
-﻿cwp_chaos_mode = {
+﻿cwp_central_bank_control = {
+	default = cwp_dynamic_control
+	cwp_player_control = {}
+	cwp_dynamic_control = {}
+	cwp_ai_control = {}
+}
+
+cwp_chaos_mode = {
 	default = cwp_no_chaos_mode
 	cwp_no_chaos_mode = {}
 	cwp_chaos_mode_on = {}

--- a/common/journal_entries/CWP_MONETARY.txt
+++ b/common/journal_entries/CWP_MONETARY.txt
@@ -264,8 +264,8 @@ je_bretton_woods_agreement = {
 					custom_tooltip = {
 						text = US_MONEY_SUPPLY_ABOVE_20
 						or = {
-							c:USA.inflation_rate > 5
-							c:USA.inflation_rate < 0
+							c:USA.inflation_value > 5
+							c:USA.inflation_value < -0.5
 						}
 					}
 					

--- a/common/journal_entries/CWP_MONETARY.txt
+++ b/common/journal_entries/CWP_MONETARY.txt
@@ -264,8 +264,8 @@ je_bretton_woods_agreement = {
 					custom_tooltip = {
 						text = US_MONEY_SUPPLY_ABOVE_20
 						or = {
-							c:USA.money_supply_percentage >= 20
-							c:USA.money_supply_percentage <= -20
+							c:USA.inflation_rate > 5
+							c:USA.inflation_rate < 0
 						}
 					}
 					

--- a/common/modifiers/cwp_fiscal_modifiers.txt
+++ b/common/modifiers/cwp_fiscal_modifiers.txt
@@ -40,11 +40,6 @@ expansionary_monetary_policy = {
 	country_minting_add = 1
 }
 
-contractionary_monetary_policy = {
-	icon = gfx/interface/icons/timed_modifier_icons/modifier_corruption.dds
-	country_expenses_add = 1
-}
-
 interest_rates = {
 	icon = gfx/interface/icons/timed_modifier_icons/modifier_corruption.dds
 	country_loan_interest_rate_add = 0.01

--- a/common/modifiers/cwp_fiscal_modifiers.txt
+++ b/common/modifiers/cwp_fiscal_modifiers.txt
@@ -43,13 +43,13 @@ expansionary_monetary_policy = {
 interest_rates = {
 	icon = gfx/interface/icons/timed_modifier_icons/modifier_corruption.dds
 	country_loan_interest_rate_add = 0.01
-	building_group_bg_financial_services_throughput_mult = -0.01
-	state_administrators_investment_pool_efficiency_mult = -0.005
-	state_clergy_investment_pool_efficiency_mult = -0.005
-	state_farmers_investment_pool_efficiency_mult = -0.005
-	state_investors_investment_pool_efficiency_mult = -0.005
-	state_landlords_investment_pool_efficiency_mult = -0.005
-	state_professionals_investment_pool_efficiency_mult = -0.005
+	building_group_bg_financial_services_throughput_mult = -0.005
+	state_administrators_investment_pool_efficiency_mult = -0.0025
+	state_clergy_investment_pool_efficiency_mult = -0.0025
+	state_farmers_investment_pool_efficiency_mult = -0.0025
+	state_investors_investment_pool_efficiency_mult = -0.0025
+	state_landlords_investment_pool_efficiency_mult = -0.0025
+	state_professionals_investment_pool_efficiency_mult = -0.0025
 }
 
 weak_currency = {

--- a/common/modifiers/cwp_fiscal_modifiers.txt
+++ b/common/modifiers/cwp_fiscal_modifiers.txt
@@ -43,6 +43,13 @@ expansionary_monetary_policy = {
 interest_rates = {
 	icon = gfx/interface/icons/timed_modifier_icons/modifier_corruption.dds
 	country_loan_interest_rate_add = 0.01
+	building_group_bg_financial_services_throughput_mult = -0.01
+	state_administrators_investment_pool_efficiency_mult = -0.005
+	state_clergy_investment_pool_efficiency_mult = -0.005
+	state_farmers_investment_pool_efficiency_mult = -0.005
+	state_investors_investment_pool_efficiency_mult = -0.005
+	state_landlords_investment_pool_efficiency_mult = -0.005
+	state_professionals_investment_pool_efficiency_mult = -0.005
 }
 
 weak_currency = {

--- a/common/script_values/fiscal_ai_values.txt
+++ b/common/script_values/fiscal_ai_values.txt
@@ -219,6 +219,12 @@ ai_wants_contractionary = {
 		}
 		multiply = 0
 	}
+	if = {
+		limit = {
+			inflation_rate < 0
+		}
+		multiply = 0
+	}
 }
 
 ai_wants_stable = {
@@ -270,6 +276,12 @@ ai_wants_stable = {
 	if = {
 		limit = {
 			has_healthy_economy = no
+		}
+		multiply = 0
+	}
+	if = {
+		limit = {
+			inflation_rate < 0
 		}
 		multiply = 0
 	}
@@ -368,6 +380,12 @@ ai_wants_expansionary = {
 			gold_reserve_ratio > 0.75
 		}
 		multiply = 0.5
+	}
+	if = {
+		limit = {
+			inflation_rate < 0
+		}
+		add = 1000
 	}
 }
 

--- a/common/script_values/fiscal_ai_values.txt
+++ b/common/script_values/fiscal_ai_values.txt
@@ -156,47 +156,6 @@ ai_wants_contractionary = {
 	}
 	if = {
 		limit = {
-			has_journal_entry = je_bretton_woods_agreement
-		}
-		if = {
-			limit = {
-				money_supply_percentage >= 5
-			}
-			add = 50
-		}
-		if = {
-			limit = {
-				money_supply_percentage >= 10
-			}
-			add = 50
-		}
-		if = {
-			limit = {
-				money_supply_percentage >= 15
-			}
-			add = 50
-		}
-		if = {
-			limit = {
-				money_supply_percentage <= -5
-			}
-			add = -50
-		}
-		if = {
-			limit = {
-				money_supply_percentage <= -10
-			}
-			add = -50
-		}
-		if = {
-			limit = {
-				money_supply_percentage <= -15
-			}
-			add = -50
-		}
-	}
-	if = {
-		limit = {
 			gold_reserve_ratio > 0.5
 		}
 		add = 50
@@ -242,18 +201,6 @@ ai_wants_stable = {
 			}
 		}
 		add = 100
-	}
-	if = {
-		limit = {
-			has_journal_entry = je_bretton_woods_agreement
-		}
-		if = {
-			limit = {
-				money_supply_percentage <= 5
-				money_supply_percentage >= -5
-			}
-			add = 50
-		}
 	}
 	if = {
 		limit = {
@@ -327,47 +274,6 @@ ai_wants_expansionary = {
 			scaled_debt >= 0.75
 		}
 		add = 50
-	}
-	if = {
-		limit = {
-			has_journal_entry = je_bretton_woods_agreement
-		}
-		if = {
-			limit = {
-				money_supply_percentage <= -5
-			}
-			add = 50
-		}
-		if = {
-			limit = {
-				money_supply_percentage <= -10
-			}
-			add = 50
-		}
-		if = {
-			limit = {
-				money_supply_percentage <= -15
-			}
-			add = 50
-		}
-		if = {
-			limit = {
-				money_supply_percentage >= 5
-			}
-			add = -50
-		}
-		if = {
-			limit = {
-				money_supply_percentage >= 10
-			}
-			add = -50
-		}
-		if = {
-			limit = {
-				money_supply_percentage >= 15
-			}
-			add = -50
-		}
 	}
 	if = {
 		limit = {

--- a/common/script_values/fiscal_ai_values.txt
+++ b/common/script_values/fiscal_ai_values.txt
@@ -151,7 +151,7 @@ ai_wants_contractionary = {
 		}
 		add = { 
 			value = inflation_growth
-			multiply = 100
+			multiply = 1000
 		}
 	}
 	if = {
@@ -180,7 +180,7 @@ ai_wants_contractionary = {
 	}
 	if = {
 		limit = {
-			inflation_rate < 0
+			inflation_value < 0
 		}
 		multiply = 0
 	}
@@ -200,7 +200,7 @@ ai_wants_stable = {
 				}
 			}
 		}
-		add = 100
+		add = 1000
 	}
 	if = {
 		limit = {
@@ -228,7 +228,7 @@ ai_wants_stable = {
 	}
 	if = {
 		limit = {
-			inflation_rate < 0
+			inflation_value < 0
 		}
 		multiply = 0
 	}
@@ -242,14 +242,14 @@ ai_wants_expansionary = {
 		}
 		add = { 
 			value = inflation_growth
-			multiply = -100
+			multiply = -1000
 		}
 	}
 	if = {
 		limit = {
 			has_healthy_economy = no
 		}
-		add = 1000
+		add = 100
 	}
 	if = {
 		limit = {
@@ -289,7 +289,7 @@ ai_wants_expansionary = {
 	}
 	if = {
 		limit = {
-			inflation_rate < 0
+			inflation_value < 0
 		}
 		add = 1000
 	}

--- a/common/script_values/fiscal_ai_values.txt
+++ b/common/script_values/fiscal_ai_values.txt
@@ -4,9 +4,10 @@
 	max = 100
 	min = -1.5
 }
+
 player_ideal_interest_rate = {
 	value = ai_ideal_interest_rate
-	round = yes
+	round_to = 0.5
 }
 
 ai_interest_from_inflation = {  # Reduce existing inflation/deflation
@@ -145,88 +146,228 @@ ai_interest_rate_from_growth = {  # Base interest rate change to stabilize growt
 ai_wants_contractionary = {
 	if = {
 		limit = {
-			money_supply_percentage >= 50
+			ai_interest_from_inflation >= 0
+			inflation_growth > 0
+		}
+		add = { 
+			value = inflation_growth
+			multiply = 100
+		}
+	}
+	if = {
+		limit = {
+			has_journal_entry = je_bretton_woods_agreement
+		}
+		if = {
+			limit = {
+				money_supply_percentage >= 5
+			}
+			add = 50
+		}
+		if = {
+			limit = {
+				money_supply_percentage >= 10
+			}
+			add = 50
+		}
+		if = {
+			limit = {
+				money_supply_percentage >= 15
+			}
+			add = 50
+		}
+		if = {
+			limit = {
+				money_supply_percentage <= -5
+			}
+			add = -50
+		}
+		if = {
+			limit = {
+				money_supply_percentage <= -10
+			}
+			add = -50
+		}
+		if = {
+			limit = {
+				money_supply_percentage <= -15
+			}
+			add = -50
+		}
+	}
+	if = {
+		limit = {
+			gold_reserve_ratio > 0.5
 		}
 		add = 50
 	}
 	if = {
 		limit = {
-			money_supply_percentage >= 30
-		}
-		add = 30
-	}
-	if = {
-		limit = {
-			money_supply_percentage >= 15
-		}
-		add = 30
-	}
-	if = {
-		limit = {
-			gold_reserve_ratio >= 0.2
+			gold_reserve_ratio > 0.75
 		}
 		add = 50
 	}
 	if = {
 		limit = {
-			inflation_value >= 20
+			scaled_debt >= 0.1
 		}
-		add = 50
-   }
+		multiply = 0.25
+	}
+	if = {
+		limit = {
+			has_healthy_economy = no
+		}
+		multiply = 0
+	}
 }
 
 ai_wants_stable = {
 	if = {
 		limit = {
-			money_supply_percentage >= 5
-			money_supply_percentage <= 10
+			NOR = {
+				AND = {
+					ai_interest_from_inflation <= 0
+					inflation_growth < 0
+				}
+				AND = {
+					ai_interest_from_inflation >= 0
+					inflation_growth > 0
+				}
+			}
 		}
-		add = 50
+		add = 100
+	}
+	if = {
+		limit = {
+			has_journal_entry = je_bretton_woods_agreement
+		}
+		if = {
+			limit = {
+				money_supply_percentage <= 5
+				money_supply_percentage >= -5
+			}
+			add = 50
+		}
+	}
+	if = {
+		limit = {
+			gold_reserve_ratio > 0.5
+		}
+		multiply = 0.5
+	}
+	if = {
+		limit = {
+			gold_reserve_ratio > 0.75
+		}
+		multiply = 0.5
+	}
+	if = {
+		limit = {
+			scaled_debt >= 0.1
+		}
+		multiply = 0.5
+	}
+	if = {
+		limit = {
+			has_healthy_economy = no
+		}
+		multiply = 0
 	}
 }
 
 ai_wants_expansionary = {
 	if = {
 		limit = {
-			money_supply_percentage <= -100
+			ai_interest_from_inflation <= 0
+			inflation_growth < 0
 		}
-		add = 100
+		add = { 
+			value = inflation_growth
+			multiply = -100
+		}
 	}
 	if = {
 		limit = {
-			money_supply_percentage <= -50
+			has_healthy_economy = no
+		}
+		add = 1000
+	}
+	if = {
+		limit = {
+			scaled_debt >= 0.1
 		}
 		add = 50
 	}
 	if = {
 		limit = {
-			scaled_debt >= 0.3
+			scaled_debt >= 0.25
 		}
-		add = 15
+		add = 50
 	}
 	if = {
 		limit = {
-			money_supply_percentage <= -30
+			scaled_debt >= 0.5
 		}
-		add = 30
+		add = 50
 	}
 	if = {
 		limit = {
-			money_supply_percentage <= -15
+			scaled_debt >= 0.75
 		}
-		add = 30
+		add = 50
 	}
 	if = {
 		limit = {
-			money_supply_percentage < 5
+			has_journal_entry = je_bretton_woods_agreement
 		}
-		add = 20
+		if = {
+			limit = {
+				money_supply_percentage <= -5
+			}
+			add = 50
+		}
+		if = {
+			limit = {
+				money_supply_percentage <= -10
+			}
+			add = 50
+		}
+		if = {
+			limit = {
+				money_supply_percentage <= -15
+			}
+			add = 50
+		}
+		if = {
+			limit = {
+				money_supply_percentage >= 5
+			}
+			add = -50
+		}
+		if = {
+			limit = {
+				money_supply_percentage >= 10
+			}
+			add = -50
+		}
+		if = {
+			limit = {
+				money_supply_percentage >= 15
+			}
+			add = -50
+		}
 	}
 	if = {
 		limit = {
-			inflation_value <= 0
+			gold_reserve_ratio > 0.5
 		}
-		add = 100
+		multiply = 0.5
+	}
+	if = {
+		limit = {
+			gold_reserve_ratio > 0.75
+		}
+		multiply = 0.5
 	}
 }
 

--- a/common/script_values/fiscal_values.txt
+++ b/common/script_values/fiscal_values.txt
@@ -317,24 +317,14 @@ bank_credibility_val = {
 	round = yes
 	max = 24
 }
+
 monetary_policy_mult = {
-	if = {
-		limit = {
-			has_variable = contractionary_monetary_policy
-		}
-		value = {
-			value = income
-			multiply = 0.3
-		}
-	}
-	if = {
-		limit = {
-			has_variable = expansionary_monetary_policy
-		}
-		value = {
-			value = income
-			multiply = 0.3
-		}
+	value = gdp
+	divide = 1000
+	multiply = {
+		value = 100
+		add = money_supply_percentage
+		divide = 100
 	}
 	if = {
 		limit = {

--- a/common/scripted_effects/cwp_onaction_fiscal_ai.txt
+++ b/common/scripted_effects/cwp_onaction_fiscal_ai.txt
@@ -26,7 +26,6 @@ onaction_ai_monetary_policy_calculation = {
         limit = {
             nor = {
                 has_variable = pegged_currency
-                has_law = law_type:law_gold_standard
                 AND = {
                     has_game_rule = cwp_dynamic_control
                     has_law = law_type:law_government_interference

--- a/common/scripted_effects/cwp_onaction_fiscal_ai.txt
+++ b/common/scripted_effects/cwp_onaction_fiscal_ai.txt
@@ -81,6 +81,22 @@ onaction_ai_interest_rate_calculation = {
 			name = interest_rate_gui
 			value = var:interest_rate
 		}
+        remove_modifier = interest_rates
+		if = {
+			limit = {
+				interest_rate >= 1
+			}
+			add_modifier = {
+				name = interest_rates
+				multiplier = interest_rate
+			}
+		}
+		else = {
+			add_modifier = {
+				name = interest_rates
+				multiplier = 1
+			}
+		}
     }
 }
 

--- a/common/scripted_effects/cwp_onaction_fiscal_ai.txt
+++ b/common/scripted_effects/cwp_onaction_fiscal_ai.txt
@@ -1,7 +1,17 @@
 ﻿onaction_ai_fiscal_calculations = {
     if = {
         limit = {
-            is_ai = yes
+            OR = {
+                is_player = no
+                has_game_rule = cwp_ai_control
+                AND = {
+                    has_game_rule = cwp_dynamic_control
+                    OR = {
+                        has_law = law_type:law_independent_monetary_policy
+                        has_law = law_type:law_government_interference
+                    }
+                }
+            }
         }
         onaction_ai_monetary_policy_calculation = yes
         onaction_ai_interest_rate_calculation = yes
@@ -17,6 +27,10 @@ onaction_ai_monetary_policy_calculation = {
             nor = {
                 has_variable = pegged_currency
                 has_law = law_type:law_gold_standard
+                AND = {
+                    has_game_rule = cwp_dynamic_control
+                    has_law = law_type:law_government_interference
+                }
             }
         }
         random_list = {

--- a/common/scripted_effects/cwp_onaction_fiscal_effects.txt
+++ b/common/scripted_effects/cwp_onaction_fiscal_effects.txt
@@ -1,5 +1,4 @@
 ﻿onaction_fiscal_calculation = {
-
     fiscal_error_check = yes
     fiscal_money_supply_calculation = yes
     fiscal_inflation_deflation_calculation = yes
@@ -73,24 +72,9 @@ fiscal_inflation_deflation_calculation = {
 
 fiscal_monetary_policy_calculation = {
     remove_modifier = expansionary_monetary_policy
-    remove_modifier = contractionary_monetary_policy
-    if = {
-        limit = {
-            has_variable = contractionary_monetary_policy
-        }
-        add_modifier = {
-            name = contractionary_monetary_policy
-            multiplier = monetary_policy_mult
-        }
-    }
-    else_if = {
-        limit = {
-            has_variable = expansionary_monetary_policy
-        }
-        add_modifier = {
-            name = expansionary_monetary_policy
-            multiplier = monetary_policy_mult
-        }
+    add_modifier = {
+        name = expansionary_monetary_policy
+        multiplier = monetary_policy_mult
     }
 }
 

--- a/common/scripted_guis/fiscal_sgui.txt
+++ b/common/scripted_guis/fiscal_sgui.txt
@@ -170,7 +170,7 @@ submit_interest_rate = {
 		}
 		set_variable = {
 			name = changed_interest_rates
-			months = 6
+			months = 3
 		}
 		remove_modifier = interest_rates
 		if = {

--- a/common/scripted_guis/fiscal_sgui.txt
+++ b/common/scripted_guis/fiscal_sgui.txt
@@ -198,11 +198,6 @@ set_contractionary_monetary_policy = {
 		remove_variable = stable_monetary_policy
 		remove_variable = expansionary_monetary_policy
 		set_variable = contractionary_monetary_policy
-		remove_modifier = expansionary_monetary_policy
-		add_modifier = {
-			name = expansionary_monetary_policy
-			multiplier = monetary_policy_mult
-		}
 	}
 }
 
@@ -211,8 +206,6 @@ set_stable_monetary_policy = {
 		remove_variable = contractionary_monetary_policy
 		remove_variable = expansionary_monetary_policy
 		set_variable = stable_monetary_policy
-		remove_modifier = contractionary_monetary_policy
-		remove_modifier = expansionary_monetary_policy
 	}
 }
 
@@ -221,11 +214,6 @@ set_expansionary_monetary_policy = {
 		remove_variable = stable_monetary_policy
 		remove_variable = contractionary_monetary_policy
 		set_variable = expansionary_monetary_policy
-		remove_modifier = contractionary_monetary_policy
-		add_modifier = {
-			name = contractionary_monetary_policy
-			multiplier = monetary_policy_mult
-		}
 	}
 }
 

--- a/common/scripted_guis/fiscal_sgui.txt
+++ b/common/scripted_guis/fiscal_sgui.txt
@@ -364,6 +364,11 @@ can_set_contractionary = {
 			nor = {
 				has_variable = pegged_currency
 				has_variable = contractionary_monetary_policy
+				has_game_rule = cwp_ai_control
+				AND = {
+					has_game_rule = cwp_dynamic_control
+                    has_law = law_type:law_independent_monetary_policy
+				}
 			}
 		}
 	}
@@ -375,6 +380,11 @@ can_set_stable= {
 			nor = {
 				has_variable = pegged_currency
 				has_variable = stable_monetary_policy
+				has_game_rule = cwp_ai_control
+				AND = {
+					has_game_rule = cwp_dynamic_control
+                    has_law = law_type:law_independent_monetary_policy
+				}
 			}
 		}
 	}
@@ -386,6 +396,11 @@ can_set_expansionary = {
 			nor = {
 				has_variable = pegged_currency
 				has_variable = expansionary_monetary_policy
+				has_game_rule = cwp_ai_control
+				AND = {
+					has_game_rule = cwp_dynamic_control
+                    has_law = law_type:law_independent_monetary_policy
+				}
 			}
 		}
 	}
@@ -399,6 +414,14 @@ can_set_interest_rates = {
 				has_law = law_type:law_gold_standard
 				has_law = law_type:law_pegged_currency
 				has_variable = changed_interest_rates
+				has_game_rule = cwp_ai_control
+                AND = {
+                    has_game_rule = cwp_dynamic_control
+                    OR = {
+                        has_law = law_type:law_independent_monetary_policy
+                        has_law = law_type:law_government_interference
+                    }
+                }
 			}
 		}
 	}

--- a/events/CWP_events/france_events/a_new_constitution.txt
+++ b/events/CWP_events/france_events/a_new_constitution.txt
@@ -275,7 +275,7 @@ a_new_constitution.210 = {
 			remove_variable = fra_constitutional_referendum_on_pause
 		}
 		ai_chance = {
-			base = 60
+			base = 30
 		}
 	}
 	#OPT Council Elective
@@ -308,7 +308,7 @@ a_new_constitution.210 = {
 			remove_variable = fra_constitutional_referendum_on_pause
 		}
 		ai_chance = {
-			base = 60
+			base = 5
 		}
 	}
 }
@@ -399,7 +399,7 @@ a_new_constitution.211 = {
 			remove_variable = fra_constitutional_referendum_on_pause
 		}
 		ai_chance = {
-			base = 60
+			base = 30
 		}
 	}
 	#OPT Direct Democracy
@@ -432,7 +432,7 @@ a_new_constitution.211 = {
 			remove_variable = fra_constitutional_referendum_on_pause
 		}
 		ai_chance = {
-			base = 60
+			base = 5
 		}
 	}
 }
@@ -613,7 +613,7 @@ a_new_constitution.213 = {
 			remove_variable = fra_constitutional_referendum_on_pause
 		}
 		ai_chance = {
-			base = 60
+			base = 30
 		}
 	}
 	#OPT interventionism
@@ -680,7 +680,7 @@ a_new_constitution.213 = {
 			remove_variable = fra_constitutional_referendum_on_pause
 		}
 		ai_chance = {
-			base = 60
+			base = 5
 		}
 	}
 }

--- a/events/CWP_events/india_events/indian_partition_events.txt
+++ b/events/CWP_events/india_events/indian_partition_events.txt
@@ -513,7 +513,9 @@ indian_partition.2 = {
 	option = {
 		name = indian_partition.2.c
 		trigger = {
-			global_var:indian_national_unity >= 25
+			c:HND = {
+				this.relations:root > 25
+			}
 		}
 		hidden_effect = {
 			if = {

--- a/localization/english/CWP/CWP_fiscal_l_english.yml
+++ b/localization/english/CWP/CWP_fiscal_l_english.yml
@@ -160,7 +160,7 @@ je_bretton_woods_agreement: "Bretton Woods Agreement"
 je_bretton_woods_agreement_reason: "[SelectLocalization(GetScriptedGui('bretton_woods_is_usa_enabled').IsShown( GuiScope.SetRoot(GetPlayer.MakeScope).End), 'BRETTON_WOODS_USA', 'BRETTON_WOODS_OTHER')]"
 bretton_woods_agreement_status_desc: "Currently #v [GetDataModelSize(GetGlobalList('bretton_woods_members'))]#! Signatory Countries"
 US_HAS_NO_GOLD_STANDARD: "#t The United States#! has any other #v [concept_monetary_policy]#! than #v $law_gold_standard$#!"
-US_MONEY_SUPPLY_ABOVE_20: "#t The United States#! has either #p +20% [concept_money_supply]#! or #n -20% [concept_money_supply]"
+US_MONEY_SUPPLY_ABOVE_20: "#t The United States#! has either above #p +5% [concept_inflation_rate]#! or below #n 0% [concept_inflation_rate]"
 
 
 WILL_WITHDRAW_BRETTON_WOODS: "Will end the #v Bretton Woods Agreement#!"

--- a/localization/english/CWP/CWP_modifiers_l_english.yml
+++ b/localization/english/CWP/CWP_modifiers_l_english.yml
@@ -2,8 +2,7 @@
   ####################################################
   ###################### Fiscal ######################
   ####################################################
-  contractionary_monetary_policy: "Contractionary Monetary Policy"
-  expansionary_monetary_policy: "Expansionary Monetary Policy"
+  expansionary_monetary_policy: "Monetary Supply Growth"
   strong_currency: "Strong Currency"
   weak_currency: "Weak Currency"
   inflation: "Inflation"

--- a/localization/english/CWP/cwp_game_rules_l_english.yml
+++ b/localization/english/CWP/cwp_game_rules_l_english.yml
@@ -4,3 +4,11 @@
   setting_cwp_no_chaos_mode_desc: "A normal game."
 	setting_cwp_chaos_mode_on: "Chaos Mode!"
   setting_cwp_chaos_mode_on_desc: "A game with a twist. #warning This mode is unsupported and will cause issues with the game. #bold Use at your own risk! #! #!"
+
+  rule_cwp_central_bank_control: "Central Bank Control"
+	setting_cwp_player_control: "Player Control"
+  setting_cwp_player_control_desc: "The player controls the Central Bank at all times."
+	setting_cwp_dynamic_control: "Dynamic Control"
+  setting_cwp_dynamic_control_desc: "Control of the Central Bank is dependent on laws."
+	setting_cwp_ai_control: "AI Control"
+  setting_cwp_ai_control_desc: "The AI controls the Central Bank at all times."


### PR DESCRIPTION
- minting is now determined by money supply percentage (this is to help with ai budget calculations, primarily)
- added negative effects to interest rates so optimal play no longer involves extended periods at 20%+ interest (lmao)
- fixed gold standard preventing ai from modifying monetary supply, collapsing bretton-woods early
- added a game rule for central bank control
- added varying levels of automation for different laws using dynamic control game rule
- fixed french constitution JE going communist too often
- fixed india becoming a protectorate too often