### PR TITLE
Philippines - Cosmetic names

### DIFF
--- a/common/dynamic_country_names/00_dynamic_country_names.txt
+++ b/common/dynamic_country_names/00_dynamic_country_names.txt
@@ -2215,7 +2215,19 @@ PHI = {
 			scope:actor = {
 				is_subject = no
 			}
-			coa_def_dictatorship_flag_trigger = yes
+			coa_def_absolute_monarchy_flag_trigger = yes
+		}
+	}
+	dynamic_country_name = {
+		name = dyn_c_kapatiran_liga
+		adjective = dyn_c_kapatiran_liga_adj
+		is_main_tag_only = yes
+		priority = 5
+		trigger = {
+			scope:actor = {
+				is_subject = no
+			}
+			coa_def_communist_flag_trigger = yes
 		}
 	}
 }

--- a/localization/english/countries_l_english.yml
+++ b/localization/english/countries_l_english.yml
@@ -1066,6 +1066,8 @@
   #PHI - Philippines
   dyn_c_maharlika: "Mahárlika"
   dyn_c_maharlika_adj: "Mahárlikan"
+  dyn_c_kapatiran_liga: "Kapatiran Liga"
+  dyn_c_kapatiran_liga_adj: "Kapatiran"
 
   ###Eastern Asia###
   #FER - Kamchatka


### PR DESCRIPTION
Mahárlika is now triggered only when PHI is an absolute moarchy
Communist PHI is now called Kapatiran Liga