### PR TITLE
Housing and healthcare removed from buy pachages

### DIFF
--- a/common/buy_packages/00_buy_packages.txt
+++ b/common/buy_packages/00_buy_packages.txt
@@ -1,0 +1,1858 @@
+﻿wealth_1 = {
+	political_strength = 0.1
+    goods = {
+		popneed_basic_food = 62
+		popneed_basic_intoxicants = 19
+		popneed_heating = 13
+		popneed_simple_clothing = 17
+		popneed_standard_clothing = 2
+		popneed_transportation = 8
+	}
+}
+
+wealth_2 = {
+	political_strength = 0.2
+    goods = {
+		popneed_basic_food = 65
+		popneed_basic_intoxicants = 19
+		popneed_heating = 13
+		popneed_simple_clothing = 20
+		popneed_standard_clothing = 3
+		popneed_transportation = 8
+	}
+}
+
+wealth_3 = {
+	political_strength = 0.3
+    goods = {
+		popneed_basic_food = 69
+		popneed_basic_intoxicants = 20
+		popneed_heating = 14
+		popneed_simple_clothing = 23
+		popneed_standard_clothing = 5
+		popneed_transportation = 8
+	}
+}
+
+wealth_4 = {
+	political_strength = 0.4
+    goods = {
+		popneed_basic_food = 72
+		popneed_basic_intoxicants = 21
+		popneed_crude_items = 1
+		popneed_heating = 14
+		popneed_services = 2
+		popneed_simple_clothing = 25
+		popneed_standard_clothing = 7
+		popneed_transportation = 8
+	}
+}
+
+wealth_5 = {
+	political_strength = 0.5
+    goods = {
+		popneed_basic_food = 74
+		popneed_basic_intoxicants = 21
+		popneed_crude_items = 8
+		popneed_heating = 14
+		popneed_services = 4
+		popneed_simple_clothing = 27
+		popneed_standard_clothing = 9
+		popneed_transportation = 12
+	}
+}
+
+wealth_6 = {
+	political_strength = 0.6
+    goods = {
+		popneed_basic_food = 76
+		popneed_basic_intoxicants = 21
+		popneed_crude_items = 14
+		popneed_heating = 14
+		popneed_services = 6
+		popneed_simple_clothing = 28
+		popneed_standard_clothing = 11
+		popneed_transportation = 12
+	}
+}
+
+wealth_7 = {
+	political_strength = 0.7
+    goods = {
+		popneed_basic_food = 79
+		popneed_basic_intoxicants = 21
+		popneed_crude_items = 19
+		popneed_heating = 15
+		popneed_household_items = 4
+		popneed_services = 8
+		popneed_simple_clothing = 29
+		popneed_standard_clothing = 13
+		popneed_transportation = 16
+	}
+}
+
+wealth_8 = {
+	political_strength = 0.8
+    goods = {
+		popneed_basic_food = 82
+		popneed_basic_intoxicants = 22
+		popneed_crude_items = 24
+		popneed_heating = 15
+		popneed_household_items = 4
+		popneed_media = 1
+		popneed_services = 11
+		popneed_simple_clothing = 30
+		popneed_standard_clothing = 16
+		popneed_transportation = 16
+	}
+}
+
+wealth_9 = {
+	political_strength = 0.9
+    goods = {
+		popneed_basic_food = 86
+		popneed_basic_intoxicants = 22
+		popneed_crude_items = 27
+		popneed_free_movement = 14
+		popneed_heating = 15
+		popneed_household_items = 4
+		popneed_media = 2
+		popneed_services = 14
+		popneed_simple_clothing = 30
+		popneed_standard_clothing = 19
+		popneed_transportation = 20
+	}
+}
+
+wealth_10 = {
+	political_strength = 1.0
+    goods = {
+		popneed_basic_food = 90
+		popneed_basic_intoxicants = 23
+		popneed_crude_items = 28
+		popneed_free_movement = 8
+		popneed_heating = 16
+		popneed_household_items = 4
+		popneed_media = 4
+		popneed_services = 17
+		popneed_simple_clothing = 29
+		popneed_standard_clothing = 22
+		popneed_transportation = 20
+	}
+}
+
+wealth_11 = {
+	political_strength = 1.1
+    goods = {
+		popneed_basic_food = 94
+		popneed_basic_intoxicants = 23
+		popneed_crude_items = 27
+		popneed_financial_services = 1
+		popneed_free_movement = 8
+		popneed_heating = 16
+		popneed_household_items = 13
+		popneed_media = 5
+		popneed_services = 20
+		popneed_simple_clothing = 26
+		popneed_standard_clothing = 26		
+		popneed_transportation = 24
+	}
+}
+
+wealth_12 = {
+	political_strength = 2.79
+    goods = {
+		popneed_basic_food = 99
+		popneed_basic_intoxicants = 23
+		popneed_crude_items = 24
+		popneed_financial_services = 2
+		popneed_free_movement = 10
+		popneed_heating = 17
+		popneed_household_items = 21
+		popneed_media = 8
+		popneed_services = 25
+		popneed_simple_clothing = 22
+		popneed_standard_clothing = 30
+		popneed_transportation = 24
+	}
+}
+
+wealth_13 = {
+	political_strength = 4.48
+    goods = {
+		popneed_basic_food = 104
+		popneed_basic_intoxicants = 23
+		popneed_crude_items = 16
+		popneed_financial_services = 4
+		popneed_free_movement = 12
+		popneed_heating = 17
+		popneed_household_items = 30
+		popneed_luxury_drinks = 4
+		popneed_luxury_intoxicants = 1
+		popneed_media = 10
+		popneed_services = 30
+		popneed_simple_clothing = 16
+		popneed_standard_clothing = 35
+		popneed_transportation = 26
+	}
+}
+
+wealth_14 = {
+	political_strength = 6.18
+    goods = {
+		popneed_basic_food = 111
+		popneed_basic_intoxicants = 23
+		popneed_crude_items = 3
+		popneed_financial_services = 6
+		popneed_free_movement = 12
+		popneed_heating = 18
+		popneed_household_items = 40
+		popneed_luxury_drinks = 9
+		popneed_luxury_intoxicants = 1
+		popneed_media = 14
+		popneed_services = 36
+		popneed_simple_clothing = 6
+		popneed_standard_clothing = 41
+		popneed_transportation = 26
+	}
+}
+
+wealth_15 = {
+	political_strength = 7.87
+    goods = {
+		popneed_basic_food = 114
+		popneed_basic_intoxicants = 23
+		popneed_financial_services = 8
+		popneed_free_movement = 14
+		popneed_heating = 19
+		popneed_household_items = 48
+		popneed_luxury_drinks = 14
+		popneed_luxury_intoxicants = 2
+		popneed_luxury_items = 1
+		popneed_media = 17
+		popneed_services = 41
+		popneed_standard_clothing = 46
+		popneed_transportation = 28
+	}
+}
+
+wealth_16 = {
+	political_strength = 9.56
+    goods = {
+		popneed_basic_food = 114
+		popneed_basic_intoxicants = 21
+		popneed_financial_services = 10
+		popneed_free_movement = 14
+		popneed_heating = 18
+		popneed_household_items = 54
+		popneed_luxury_drinks = 19
+		popneed_luxury_intoxicants = 3
+		popneed_luxury_items = 7
+		popneed_media = 21
+		popneed_services = 46
+		popneed_standard_clothing = 50
+		popneed_transportation = 28
+	}
+}
+
+wealth_17 = {
+	political_strength = 11.25
+    goods = {
+		popneed_basic_food = 113
+		popneed_basic_intoxicants = 19
+		popneed_communication = 1
+		popneed_financial_services = 13
+		popneed_free_movement = 16
+		popneed_heating = 18
+		popneed_household_items = 59
+		popneed_luxury_drinks = 24
+		popneed_luxury_intoxicants = 4
+		popneed_luxury_items = 14
+		popneed_media = 25
+		popneed_services = 51
+		popneed_standard_clothing = 54
+		popneed_tourism = 2
+		popneed_transportation = 24
+	}
+}
+
+wealth_18 = {
+	political_strength = 12.94
+    goods = {
+		popneed_basic_food = 113
+		popneed_basic_intoxicants = 16
+		popneed_communication = 3
+		popneed_financial_services = 16
+		popneed_free_movement = 16
+		popneed_heating = 18
+		popneed_household_items = 63
+		popneed_luxury_intoxicants = 5
+		popneed_luxury_items = 22
+		popneed_media = 29
+		popneed_services = 56
+		popneed_standard_clothing = 58
+		popneed_luxury_drinks = 30
+		popneed_tourism = 4
+		popneed_transportation = 24
+	}
+}
+
+wealth_19 = {
+	political_strength = 14.64
+    goods = {
+		popneed_basic_food = 112
+		popneed_basic_intoxicants = 14
+		popneed_communication = 5
+		popneed_financial_services = 19
+		popneed_free_movement = 24
+		popneed_heating = 17
+		popneed_household_items = 67
+		popneed_luxury_drinks = 36
+		popneed_luxury_intoxicants = 6
+		popneed_luxury_items = 31
+		popneed_media = 34
+		popneed_services = 62
+		popneed_standard_clothing = 62
+		popneed_tourism = 7
+		popneed_transportation = 20
+	}
+}
+
+wealth_20 = {
+	political_strength = 16.33
+    goods = {
+		popneed_basic_food = 111
+		popneed_basic_intoxicants = 11
+		popneed_communication = 7
+		popneed_financial_services = 23
+		popneed_free_movement = 24
+		popneed_heating = 17
+		popneed_household_items = 70
+		popneed_luxury_drinks = 42
+		popneed_luxury_intoxicants = 7
+		popneed_luxury_items = 42
+		popneed_media = 39
+		popneed_services = 69
+		popneed_standard_clothing = 67
+		popneed_tourism = 9
+		popneed_transportation = 20
+	}
+}
+
+wealth_21 = {
+	political_strength = 18.02
+    goods = {
+		popneed_basic_food = 108
+		popneed_basic_intoxicants = 7
+		popneed_communication = 9
+		popneed_financial_services = 27
+		popneed_free_movement = 28
+		popneed_heating = 17
+		popneed_household_items = 73
+		popneed_luxury_drinks = 49
+		popneed_luxury_food = 6
+		popneed_luxury_intoxicants = 9
+		popneed_luxury_items = 54
+		popneed_media = 45
+		popneed_services = 75
+		popneed_standard_clothing = 71
+		popneed_tourism = 12
+		popneed_transportation = 12
+	}
+}
+
+wealth_22 = {
+	political_strength = 19.71
+    goods = {
+		popneed_basic_food = 105
+		popneed_basic_intoxicants = 2
+		popneed_communication = 11
+		popneed_financial_services = 31
+		popneed_free_movement = 32
+		popneed_heating = 16
+		popneed_household_items = 74
+		popneed_luxury_drinks = 55
+		popneed_luxury_food = 15
+		popneed_luxury_intoxicants = 10
+		popneed_luxury_items = 67
+		popneed_services = 82
+		popneed_standard_clothing = 75
+		popneed_tourism = 16
+		popneed_transportation = 12
+	}
+}
+
+wealth_23 = {
+	political_strength = 21.4
+    goods = {
+		popneed_basic_food = 101
+		popneed_communication = 14
+		popneed_financial_services = 36
+		popneed_free_movement = 37
+		popneed_heating = 16
+		popneed_household_items = 75
+		popneed_luxury_drinks = 62
+		popneed_luxury_food = 24
+		popneed_luxury_intoxicants = 12As
+		popneed_luxury_items = 81
+		popneed_media = 58
+		popneed_services = 90
+		popneed_standard_clothing = 79
+		popneed_tourism = 20
+		popneed_transportation = 10
+	}
+}
+
+wealth_24 = {
+	political_strength = 23.1
+    goods = {
+		popneed_basic_food = 96
+		popneed_communication = 17
+		popneed_financial_services = 41
+		popneed_free_movement = 42
+		popneed_heating = 15
+		popneed_household_items = 75
+		popneed_luxury_drinks = 70
+		popneed_luxury_food = 34
+		popneed_luxury_intoxicants = 14
+		popneed_luxury_items = 97
+		popneed_media = 66
+		popneed_services = 98
+		popneed_standard_clothing = 82
+		popneed_tourism = 24
+		popneed_transportation = 10
+	}
+}
+
+wealth_25 = {
+	political_strength = 24.79
+    goods = {
+		popneed_basic_food = 90
+		popneed_communication = 20
+		popneed_financial_services = 47
+		popneed_free_movement = 47
+		popneed_heating = 15
+		popneed_household_items = 74
+		popneed_luxury_drinks = 78
+		popneed_luxury_food = 45
+		popneed_luxury_intoxicants = 16
+		popneed_luxury_items = 115
+		popneed_media = 74
+		popneed_services = 106
+		popneed_standard_clothing = 86
+		popneed_tourism = 29
+	}
+}
+
+wealth_26 = {
+	political_strength = 26.48
+    goods = {
+		popneed_basic_food = 83
+		popneed_communication = 24
+		popneed_financial_services = 54
+		popneed_free_movement = 54
+		popneed_heating = 14
+		popneed_household_items = 74
+		popneed_luxury_drinks = 86
+		popneed_luxury_food = 56
+		popneed_luxury_intoxicants = 19
+		popneed_luxury_items = 135
+		popneed_media = 84
+		popneed_services = 116
+		popneed_standard_clothing = 89
+		popneed_tourism = 34
+	}
+}
+
+wealth_27 = {
+	political_strength = 28.17
+    goods = {
+		popneed_basic_food = 75
+		popneed_communication = 28
+		popneed_financial_services = 62
+		popneed_free_movement = 60
+		popneed_heating = 14
+		popneed_household_items = 73
+		popneed_luxury_drinks = 95
+		popneed_luxury_food = 68
+		popneed_luxury_intoxicants = 21
+		popneed_luxury_items = 157
+		popneed_media = 95
+		popneed_services = 126
+		popneed_standard_clothing = 92
+		popneed_tourism = 40
+	}
+}
+
+wealth_28 = {
+	political_strength = 29.86
+    goods = {
+		popneed_basic_food = 65
+		popneed_communication = 33
+		popneed_financial_services = 71
+		popneed_free_movement = 68
+		popneed_heating = 15
+		popneed_household_items = 72
+		popneed_luxury_drinks = 104
+		popneed_luxury_food = 81
+		popneed_luxury_intoxicants = 25
+		popneed_luxury_items = 182
+		popneed_media = 107
+		popneed_services = 137
+		popneed_standard_clothing = 94
+		popneed_tourism = 47
+	}
+}
+
+wealth_29 = {
+	political_strength = 31.56
+    goods = {
+		popneed_basic_food = 54
+		popneed_communication = 38
+		popneed_financial_services = 80
+		popneed_free_movement = 76
+		popneed_heating = 17
+		popneed_household_items = 70
+		popneed_luxury_drinks = 114
+		popneed_luxury_food = 95
+		popneed_luxury_intoxicants = 28
+		popneed_luxury_items = 209
+		popneed_media = 120
+		popneed_services = 149
+		popneed_standard_clothing = 95
+		popneed_tourism = 55
+	}
+}
+
+wealth_30 = {
+	political_strength = 33.25
+    goods = {
+		popneed_basic_food = 40
+		popneed_communication = 44
+		popneed_financial_services = 91
+		popneed_free_movement = 85
+		popneed_heating = 18
+		popneed_household_items = 69
+		popneed_luxury_drinks = 125
+		popneed_luxury_food = 109
+		popneed_luxury_intoxicants = 32
+		popneed_luxury_items = 239
+		popneed_media = 135
+		popneed_services = 162
+		popneed_standard_clothing = 96
+		popneed_tourism = 64
+	}
+}
+
+wealth_31 = {
+	political_strength = 34.94
+    goods = {
+		popneed_basic_food = 24
+		popneed_communication = 50
+		popneed_financial_services = 104
+		popneed_free_movement = 95
+		popneed_heating = 20
+		popneed_household_items = 68
+		popneed_luxury_drinks = 137
+		popneed_luxury_food = 125
+		popneed_luxury_intoxicants = 37
+		popneed_luxury_items = 273
+		popneed_media = 152
+		popneed_services = 177
+		popneed_standard_clothing = 95
+		popneed_tourism = 74
+	}
+}
+
+wealth_32 = {
+	political_strength = 36.63
+    goods = {
+		popneed_basic_food = 5
+		popneed_communication = 58
+		popneed_financial_services = 118
+		popneed_free_movement = 106
+		popneed_heating = 21
+		popneed_household_items = 66
+		popneed_luxury_drinks = 149
+		popneed_luxury_food = 142
+		popneed_luxury_intoxicants = 42
+		popneed_luxury_items = 310
+		popneed_media = 171
+		popneed_services = 192
+		popneed_standard_clothing = 93
+		popneed_tourism = 86
+	}
+}
+
+wealth_33 = {
+	political_strength = 38.33
+    goods = {
+		popneed_communication = 66
+		popneed_financial_services = 133
+		popneed_free_movement = 117
+		popneed_heating = 23
+		popneed_household_items = 64
+		popneed_luxury_drinks = 161
+		popneed_luxury_food = 160
+		popneed_luxury_intoxicants = 47
+		popneed_luxury_items = 348
+		popneed_media = 191
+		popneed_services = 208
+		popneed_standard_clothing = 88
+		popneed_tourism = 98
+	}
+}
+
+wealth_34 = {
+	political_strength = 40.02
+    goods = {
+		popneed_standard_clothing = 81
+		popneed_heating = 25
+		popneed_services = 224
+		popneed_luxury_drinks = 174
+		popneed_free_movement = 128
+		popneed_communication = 74
+		popneed_luxury_food = 178
+		popneed_luxury_items = 388
+		popneed_household_items = 62
+		popneed_financial_services = 149
+		popneed_tourism = 111
+		popneed_media = 213
+		popneed_luxury_intoxicants = 53
+	}
+}
+
+wealth_35 = {
+	political_strength = 41.71
+    goods = {
+		popneed_standard_clothing = 71
+		popneed_heating = 28
+		popneed_services = 242
+		popneed_luxury_drinks = 188
+		popneed_free_movement = 141
+		popneed_communication = 84
+		popneed_luxury_food = 197
+		popneed_luxury_items = 433
+		popneed_household_items = 59
+		popneed_financial_services = 167
+		popneed_tourism = 126
+		popneed_media = 237
+		popneed_luxury_intoxicants = 60
+	}
+}
+
+wealth_36 = {
+	political_strength = 43.4
+    goods = {
+		popneed_standard_clothing = 57
+		popneed_heating = 30
+		popneed_services = 261
+		popneed_luxury_drinks = 202
+		popneed_free_movement = 156
+		popneed_communication = 94
+		popneed_luxury_food = 217
+		popneed_luxury_items = 482
+		popneed_household_items = 56
+		popneed_financial_services = 187
+		popneed_tourism = 143
+		popneed_media = 264
+		popneed_luxury_intoxicants = 67
+	}
+}
+
+wealth_37 = {
+	political_strength = 45.09
+    goods = {
+		popneed_standard_clothing = 40
+		popneed_heating = 33
+		popneed_services = 282
+		popneed_luxury_drinks = 218
+		popneed_free_movement = 171
+		popneed_communication = 106
+		popneed_luxury_food = 239
+		popneed_luxury_items = 535
+		popneed_household_items = 51
+		popneed_financial_services = 210
+		popneed_tourism = 163
+		popneed_media = 294
+		popneed_luxury_intoxicants = 76
+	}
+}
+
+wealth_38 = {
+	political_strength = 46.79
+    goods = {
+		popneed_standard_clothing = 36
+		popneed_heating = 36
+		popneed_services = 306
+		popneed_luxury_drinks = 235
+		popneed_free_movement = 188
+		popneed_communication = 119
+		popneed_luxury_food = 262
+		popneed_luxury_items = 593
+		popneed_household_items = 45
+		popneed_financial_services = 236
+		popneed_tourism = 184
+		popneed_media = 328
+		popneed_luxury_intoxicants = 85
+	}
+}
+
+wealth_39 = {
+	political_strength = 48.48
+    goods = {
+		popneed_standard_clothing = 39
+		popneed_heating = 39
+		popneed_services = 330
+		popneed_luxury_drinks = 253
+		popneed_free_movement = 206
+		popneed_communication = 134
+		popneed_luxury_food = 286
+		popneed_luxury_items = 656
+		popneed_household_items = 39
+		popneed_financial_services = 265
+		popneed_tourism = 208
+		popneed_media = 365
+		popneed_luxury_intoxicants = 96
+	}
+}
+
+wealth_40 = {
+	political_strength = 50.17
+    goods = {
+		popneed_standard_clothing = 42
+		popneed_heating = 42
+		popneed_services = 356
+		popneed_luxury_drinks = 271
+		popneed_free_movement = 225
+		popneed_communication = 150
+		popneed_luxury_food = 311
+		popneed_luxury_items = 720
+		popneed_household_items = 42
+		popneed_financial_services = 295
+		popneed_tourism = 234
+		popneed_media = 404
+		popneed_luxury_intoxicants = 107
+	}
+}
+
+wealth_41 = {
+	political_strength = 51.86
+    goods = {
+		popneed_standard_clothing = 46
+		popneed_heating = 46
+		popneed_services = 383
+		popneed_luxury_drinks = 290
+		popneed_free_movement = 245
+		popneed_communication = 167
+		popneed_luxury_food = 337
+		popneed_luxury_items = 790
+		popneed_household_items = 46
+		popneed_financial_services = 329
+		popneed_tourism = 263
+		popneed_media = 448
+		popneed_luxury_intoxicants = 120
+	}
+}
+
+wealth_42 = {
+	political_strength = 53.55
+    goods = {
+		popneed_standard_clothing = 50
+		popneed_heating = 50
+		popneed_services = 411
+		popneed_luxury_drinks = 310
+		popneed_free_movement = 266
+		popneed_communication = 185
+		popneed_luxury_food = 363
+		popneed_luxury_items = 862
+		popneed_household_items = 50
+		popneed_financial_services = 366
+		popneed_tourism = 295
+		popneed_media = 495
+		popneed_luxury_intoxicants = 134
+	}
+}
+
+wealth_43 = {
+	political_strength = 55.25
+    goods = {
+		popneed_standard_clothing = 55
+		popneed_heating = 55
+		popneed_services = 442
+		popneed_luxury_drinks = 330
+		popneed_free_movement = 288
+		popneed_communication = 205
+		popneed_luxury_food = 390
+		popneed_luxury_items = 939
+		popneed_household_items = 55
+		popneed_financial_services = 407
+		popneed_tourism = 329
+		popneed_media = 546
+		popneed_luxury_intoxicants = 149
+	}
+}
+
+wealth_44 = {
+	political_strength = 56.94
+    goods = {
+		popneed_standard_clothing = 60
+		popneed_heating = 60
+		popneed_services = 474
+		popneed_luxury_drinks = 352
+		popneed_free_movement = 312
+		popneed_communication = 227
+		popneed_luxury_food = 419
+		popneed_luxury_items = 1021
+		popneed_household_items = 60
+		popneed_financial_services = 452
+		popneed_tourism = 368
+		popneed_media = 603
+		popneed_luxury_intoxicants = 165
+	}
+}
+
+wealth_45 = {
+	political_strength = 58.63
+    goods = {
+		popneed_standard_clothing = 65
+		popneed_heating = 65
+		popneed_services = 510
+		popneed_luxury_drinks = 376
+		popneed_free_movement = 338
+		popneed_communication = 252
+		popneed_luxury_food = 449
+		popneed_luxury_items = 1109
+		popneed_household_items = 65
+		popneed_financial_services = 501
+		popneed_tourism = 411
+		popneed_media = 666
+		popneed_luxury_intoxicants = 184
+	}
+}
+
+wealth_46 = {
+	political_strength = 60.32
+    goods = {
+		popneed_standard_clothing = 71
+		popneed_heating = 71
+		popneed_services = 548
+		popneed_luxury_drinks = 401
+		popneed_free_movement = 366
+		popneed_communication = 279
+		popneed_luxury_food = 480
+		popneed_luxury_items = 1203
+		popneed_household_items = 71
+		popneed_financial_services = 557
+		popneed_tourism = 459
+		popneed_media = 735
+		popneed_luxury_intoxicants = 205
+	}
+}
+
+wealth_47 = {
+	political_strength = 62.01
+    goods = {
+		popneed_standard_clothing = 77
+		popneed_heating = 77
+		popneed_services = 589
+		popneed_luxury_drinks = 428
+		popneed_free_movement = 396
+		popneed_communication = 308
+		popneed_luxury_food = 513
+		popneed_luxury_items = 1304
+		popneed_household_items = 77
+		popneed_financial_services = 618
+		popneed_tourism = 512
+		popneed_media = 811
+		popneed_luxury_intoxicants = 228
+	}
+}
+
+wealth_48 = {
+	political_strength = 63.71
+    goods = {
+		popneed_standard_clothing = 84
+		popneed_heating = 84
+		popneed_services = 634
+		popneed_luxury_drinks = 457
+		popneed_free_movement = 428
+		popneed_communication = 341
+		popneed_luxury_food = 548
+		popneed_luxury_items = 1411
+		popneed_household_items = 84
+		popneed_financial_services = 686
+		popneed_tourism = 571
+		popneed_media = 896
+		popneed_luxury_intoxicants = 254
+	}
+}
+
+wealth_49 = {
+	political_strength = 65.4
+    goods = {
+		popneed_standard_clothing = 92
+		popneed_heating = 92
+		popneed_services = 683
+		popneed_luxury_drinks = 489
+		popneed_free_movement = 462
+		popneed_communication = 377
+		popneed_luxury_food = 584
+		popneed_luxury_items = 1526
+		popneed_household_items = 92
+		popneed_financial_services = 762
+		popneed_tourism = 636
+		popneed_media = 989
+		popneed_luxury_intoxicants = 282
+	}
+}
+
+wealth_50 = {
+	political_strength = 67.09
+    goods = {
+		popneed_standard_clothing = 100
+		popneed_heating = 100
+		popneed_services = 735
+		popneed_luxury_drinks = 522
+		popneed_free_movement = 499
+		popneed_communication = 416
+		popneed_luxury_food = 623
+		popneed_luxury_items = 1648
+		popneed_household_items = 100
+		popneed_financial_services = 846
+		popneed_tourism = 709
+		popneed_media = 1091
+		popneed_luxury_intoxicants = 314
+	}
+}
+
+wealth_51 = {
+	political_strength = 68.78
+    goods = {
+		popneed_standard_clothing = 109
+		popneed_heating = 109
+		popneed_services = 792
+		popneed_luxury_drinks = 558
+		popneed_free_movement = 539
+		popneed_communication = 459
+		popneed_luxury_food = 663
+		popneed_luxury_items = 1778
+		popneed_household_items = 109
+		popneed_financial_services = 938
+		popneed_tourism = 790
+		popneed_media = 1204
+		popneed_luxury_intoxicants = 349
+	}
+}
+
+wealth_52 = {
+	political_strength = 70.47
+    goods = {
+		popneed_standard_clothing = 119
+		popneed_heating = 119
+		popneed_services = 853
+		popneed_luxury_drinks = 597
+		popneed_free_movement = 581
+		popneed_communication = 506
+		popneed_luxury_food = 705
+		popneed_luxury_items = 1916
+		popneed_household_items = 119
+		popneed_financial_services = 1041
+		popneed_tourism = 880
+		popneed_media = 1328
+		popneed_luxury_intoxicants = 388
+	}
+}
+
+wealth_53 = {
+	political_strength = 72.17
+    goods = {
+		popneed_standard_clothing = 129
+		popneed_heating = 129
+		popneed_services = 920
+		popneed_luxury_drinks = 639
+		popneed_free_movement = 627
+		popneed_communication = 558
+		popneed_luxury_food = 750
+		popneed_luxury_items = 2063
+		popneed_household_items = 129
+		popneed_financial_services = 1155
+		popneed_tourism = 979
+		popneed_media = 1465
+		popneed_luxury_intoxicants = 431
+	}
+}
+
+wealth_54 = {
+	political_strength = 73.86
+    goods = {
+		popneed_standard_clothing = 141
+		popneed_heating = 141
+		popneed_services = 992
+		popneed_luxury_drinks = 685
+		popneed_free_movement = 676
+		popneed_communication = 615
+		popneed_luxury_food = 797
+		popneed_luxury_items = 2220
+		popneed_household_items = 141
+		popneed_financial_services = 1281
+		popneed_tourism = 1090
+		popneed_media = 1616
+		popneed_luxury_intoxicants = 479
+	}
+}
+
+wealth_55 = {
+	political_strength = 75.55
+    goods = {
+		popneed_standard_clothing = 153
+		popneed_heating = 153
+		popneed_services = 1070
+		popneed_luxury_drinks = 734
+		popneed_free_movement = 729
+		popneed_communication = 677
+		popneed_luxury_food = 846
+		popneed_luxury_items = 2386
+		popneed_household_items = 153
+		popneed_financial_services = 1420
+		popneed_tourism = 1212
+		popneed_media = 1782
+		popneed_luxury_intoxicants = 532
+	}
+}
+
+wealth_56 = {
+	political_strength = 77.24
+    goods = {
+		popneed_standard_clothing = 167
+		popneed_heating = 167
+		popneed_services = 1154
+		popneed_luxury_drinks = 787
+		popneed_free_movement = 785
+		popneed_communication = 745
+		popneed_luxury_food = 898
+		popneed_luxury_items = 2563
+		popneed_household_items = 167
+		popneed_financial_services = 1574
+		popneed_tourism = 1347
+		popneed_media = 1964
+		popneed_luxury_intoxicants = 591
+	}
+}
+
+wealth_57 = {
+	political_strength = 78.93
+    goods = {
+		popneed_standard_clothing = 182
+		popneed_heating = 182
+		popneed_services = 1246
+		popneed_luxury_drinks = 845
+		popneed_free_movement = 846
+		popneed_communication = 819
+		popneed_luxury_food = 954
+		popneed_luxury_items = 2751
+		popneed_household_items = 182
+		popneed_financial_services = 1745
+		popneed_tourism = 1498
+		popneed_media = 2165
+		popneed_luxury_intoxicants = 656
+	}
+}
+
+wealth_58 = {
+	political_strength = 80.63
+    goods = {
+		popneed_standard_clothing = 198
+		popneed_heating = 198
+		popneed_services = 1346
+		popneed_luxury_drinks = 907
+		popneed_free_movement = 912
+		popneed_communication = 900
+		popneed_luxury_food = 1013
+		popneed_luxury_items = 2951
+		popneed_household_items = 198
+		popneed_financial_services = 1933
+		popneed_tourism = 1664
+		popneed_media = 2385
+		popneed_luxury_intoxicants = 728
+	}
+}
+
+wealth_59 = {
+	political_strength = 82.32
+    goods = {
+		popneed_standard_clothing = 216
+		popneed_heating = 216
+		popneed_services = 1454
+		popneed_luxury_drinks = 975
+		popneed_free_movement = 982
+		popneed_communication = 989
+		popneed_luxury_food = 1075
+		popneed_luxury_items = 3164
+		popneed_household_items = 216
+		popneed_financial_services = 2141
+		popneed_tourism = 1848
+		popneed_media = 2627
+		popneed_luxury_intoxicants = 808
+	}
+}
+
+wealth_60 = {
+	political_strength = 84.01
+    goods = {
+		popneed_standard_clothing = 235
+		popneed_heating = 235
+		popneed_services = 1571
+		popneed_luxury_drinks = 1049
+		popneed_free_movement = 1058
+		popneed_communication = 1085
+		popneed_luxury_food = 1142
+		popneed_luxury_items = 3390
+		popneed_household_items = 235
+		popneed_financial_services = 2371
+		popneed_tourism = 2051
+		popneed_media = 2893
+		popneed_luxury_intoxicants = 896
+	}
+}
+
+wealth_61 = {
+	political_strength = 85.7
+    goods = {
+		popneed_standard_clothing = 256
+		popneed_heating = 256
+		popneed_services = 1698
+		popneed_luxury_drinks = 1129
+		popneed_free_movement = 1140
+		popneed_communication = 1190
+		popneed_luxury_food = 1213
+		popneed_luxury_items = 3631
+		popneed_household_items = 256
+		popneed_financial_services = 2624
+		popneed_tourism = 2276
+		popneed_media = 3185
+		popneed_luxury_intoxicants = 994
+	}
+}
+
+wealth_62 = {
+	political_strength = 87.39
+    goods = {
+		popneed_standard_clothing = 279
+		popneed_heating = 279
+		popneed_services = 1836
+		popneed_luxury_drinks = 1216
+		popneed_free_movement = 1228
+		popneed_communication = 1304
+		popneed_luxury_food = 1290
+		popneed_luxury_items = 3888
+		popneed_household_items = 279
+		popneed_financial_services = 2904
+		popneed_tourism = 2524
+		popneed_media = 3504
+		popneed_luxury_intoxicants = 1102
+	}
+}
+
+wealth_63 = {
+	political_strength = 89.09
+    goods = {
+		popneed_standard_clothing = 304
+		popneed_heating = 304
+		popneed_services = 1986
+		popneed_luxury_drinks = 1312
+		popneed_free_movement = 1324
+		popneed_communication = 1429
+		popneed_luxury_food = 1373
+		popneed_luxury_items = 4163
+		popneed_household_items = 304
+		popneed_financial_services = 3212
+		popneed_tourism = 2797
+		popneed_media = 3854
+		popneed_luxury_intoxicants = 1221
+	}
+}
+
+wealth_64 = {
+	political_strength = 90.78
+    goods = {
+		popneed_standard_clothing = 332
+		popneed_heating = 332
+		popneed_services = 2148
+		popneed_luxury_drinks = 1416
+		popneed_free_movement = 1427
+		popneed_communication = 1564
+		popneed_luxury_food = 1462
+		popneed_luxury_items = 4456
+		popneed_household_items = 332
+		popneed_financial_services = 3552
+		popneed_tourism = 3100
+		popneed_media = 4238
+		popneed_luxury_intoxicants = 1352
+	}
+}
+
+wealth_65 = {
+	political_strength = 92.47
+    goods = {
+		popneed_standard_clothing = 361
+		popneed_heating = 361
+		popneed_services = 2325
+		popneed_luxury_drinks = 1529
+		popneed_free_movement = 1539
+		popneed_communication = 1710
+		popneed_luxury_food = 1559
+		popneed_luxury_items = 4770
+		popneed_household_items = 361
+		popneed_financial_services = 3926
+		popneed_tourism = 3433
+		popneed_media = 4657
+		popneed_luxury_intoxicants = 1497
+	}
+}
+
+wealth_66 = {
+	political_strength = 94.16
+    goods = {
+		popneed_standard_clothing = 394
+		popneed_heating = 394
+		popneed_services = 2517
+		popneed_luxury_drinks = 1653
+		popneed_free_movement = 1660
+		popneed_communication = 1869
+		popneed_luxury_food = 1665
+		popneed_luxury_items = 5107
+		popneed_household_items = 394
+		popneed_financial_services = 4338
+		popneed_tourism = 3800
+		popneed_media = 5116
+		popneed_luxury_intoxicants = 1657
+	}
+}
+
+wealth_67 = {
+	political_strength = 95.85
+    goods = {
+		popneed_standard_clothing = 429
+		popneed_heating = 429
+		popneed_services = 2726
+		popneed_luxury_drinks = 1788
+		popneed_free_movement = 1792
+		popneed_communication = 2041
+		popneed_luxury_food = 1781
+		popneed_luxury_items = 5469
+		popneed_household_items = 429
+		popneed_financial_services = 4792
+		popneed_tourism = 4205
+		popneed_media = 5618
+		popneed_luxury_intoxicants = 1834
+	}
+}
+
+wealth_68 = {
+	political_strength = 97.55
+    goods = {
+		popneed_standard_clothing = 467
+		popneed_heating = 467
+		popneed_services = 2953
+		popneed_luxury_drinks = 1936
+		popneed_free_movement = 1936
+		popneed_communication = 2226
+		popneed_luxury_food = 1909
+		popneed_luxury_items = 5860
+		popneed_household_items = 467
+		popneed_financial_services = 5290
+		popneed_tourism = 4650
+		popneed_media = 6166
+		popneed_luxury_intoxicants = 2028
+	}
+}
+
+wealth_69 = {
+	political_strength = 99.24
+    goods = {
+		popneed_standard_clothing = 509
+		popneed_heating = 509
+		popneed_services = 3200
+		popneed_luxury_drinks = 2098
+		popneed_free_movement = 2092
+		popneed_communication = 2428
+		popneed_luxury_food = 2049
+		popneed_luxury_items = 6281
+		popneed_household_items = 509
+		popneed_financial_services = 5838
+		popneed_tourism = 5141
+		popneed_media = 6766
+		popneed_luxury_intoxicants = 2243
+	}
+}
+
+wealth_70 = {
+	political_strength = 100.93
+    goods = {
+		popneed_standard_clothing = 555
+		popneed_heating = 555
+		popneed_services = 3469
+		popneed_luxury_drinks = 2274
+		popneed_free_movement = 2263
+		popneed_communication = 2644
+		popneed_luxury_food = 2204
+		popneed_luxury_items = 6738
+		popneed_household_items = 555
+		popneed_financial_services = 6441
+		popneed_tourism = 5680
+		popneed_media = 7420
+		popneed_luxury_intoxicants = 2478
+	}
+}
+
+wealth_71 = {
+	political_strength = 102.62
+    goods = {
+		popneed_standard_clothing = 605
+		popneed_heating = 605
+		popneed_services = 3761
+		popneed_luxury_drinks = 2468
+		popneed_free_movement = 2450
+		popneed_communication = 2878
+		popneed_luxury_food = 2375
+		popneed_luxury_items = 7234
+		popneed_household_items = 605
+		popneed_financial_services = 7103
+		popneed_tourism = 6274
+		popneed_media = 8133
+		popneed_luxury_intoxicants = 2738
+	}
+}
+
+wealth_72 = {
+	political_strength = 104.31
+    goods = {
+		popneed_standard_clothing = 659
+		popneed_heating = 659
+		popneed_services = 4081
+		popneed_luxury_drinks = 2680
+		popneed_free_movement = 2655
+		popneed_communication = 3131
+		popneed_luxury_food = 2566
+		popneed_luxury_items = 7774
+		popneed_household_items = 659
+		popneed_financial_services = 7831
+		popneed_tourism = 6927
+		popneed_media = 8913
+		popneed_luxury_intoxicants = 3024
+	}
+}
+
+wealth_73 = {
+	political_strength = 106.01
+    goods = {
+		popneed_standard_clothing = 719
+		popneed_heating = 719
+		popneed_services = 4428
+		popneed_luxury_drinks = 2912
+		popneed_free_movement = 2880
+		popneed_communication = 3403
+		popneed_luxury_food = 2778
+		popneed_luxury_items = 8363
+		popneed_household_items = 719
+		popneed_financial_services = 8631
+		popneed_tourism = 7645
+		popneed_media = 9764
+		popneed_luxury_intoxicants = 3339
+	}
+}
+
+wealth_74 = {
+	political_strength = 107.7
+    goods = {
+		popneed_standard_clothing = 784
+		popneed_heating = 784
+		popneed_services = 4808
+		popneed_luxury_drinks = 3167
+		popneed_free_movement = 3128
+		popneed_communication = 3696
+		popneed_luxury_food = 3015
+		popneed_luxury_items = 9010
+		popneed_household_items = 784
+		popneed_financial_services = 9510
+		popneed_tourism = 8437
+		popneed_media = 10693
+		popneed_luxury_intoxicants = 3686
+	}
+}
+
+wealth_75 = {
+	political_strength = 109.39
+    goods = {
+		popneed_standard_clothing = 855
+		popneed_heating = 855
+		popneed_services = 5224
+		popneed_luxury_drinks = 3447
+		popneed_free_movement = 3400
+		popneed_communication = 4012
+		popneed_luxury_food = 3280
+		popneed_luxury_items = 9720
+		popneed_household_items = 855
+		popneed_financial_services = 10478
+		popneed_tourism = 9308
+		popneed_media = 11707
+		popneed_luxury_intoxicants = 4068
+	}
+}
+
+wealth_76 = {
+	political_strength = 111.08
+    goods = {
+		popneed_standard_clothing = 933
+		popneed_heating = 933
+		popneed_services = 5679
+		popneed_luxury_drinks = 3754
+		popneed_free_movement = 3701
+		popneed_communication = 4354
+		popneed_luxury_food = 3577
+		popneed_luxury_items = 10503
+		popneed_household_items = 933
+		popneed_financial_services = 11546
+		popneed_tourism = 10269
+		popneed_media = 12819
+		popneed_luxury_intoxicants = 4491
+	}
+}
+
+wealth_77 = {
+	political_strength = 112.78
+    goods = {
+		popneed_standard_clothing = 1018
+		popneed_heating = 1018
+		popneed_services = 6179
+		popneed_luxury_drinks = 4094
+		popneed_free_movement = 4035
+		popneed_communication = 4722
+		popneed_luxury_food = 3910
+		popneed_luxury_items = 11369
+		popneed_household_items = 1018
+		popneed_financial_services = 12723
+		popneed_tourism = 11329
+		popneed_media = 14036
+		popneed_luxury_intoxicants = 4957
+	}
+}
+
+wealth_78 = {
+	political_strength = 114.47
+    goods = {
+		popneed_standard_clothing = 1113
+		popneed_heating = 1113
+		popneed_services = 6730
+		popneed_luxury_drinks = 4469
+		popneed_free_movement = 4406
+		popneed_communication = 5121
+		popneed_luxury_food = 4284
+		popneed_luxury_items = 12334
+		popneed_household_items = 1113
+		popneed_financial_services = 14026
+		popneed_tourism = 12505
+		popneed_media = 15375
+		popneed_luxury_intoxicants = 5476
+	}
+}
+
+wealth_79 = {
+	political_strength = 116.16
+    goods = {
+		popneed_standard_clothing = 1217
+		popneed_heating = 1217
+		popneed_services = 7340
+		popneed_luxury_drinks = 4884
+		popneed_free_movement = 4820
+		popneed_communication = 5555
+		popneed_luxury_food = 4708
+		popneed_luxury_items = 13410
+		popneed_household_items = 1217
+		popneed_financial_services = 15473
+		popneed_tourism = 13811
+		popneed_media = 16850
+		popneed_luxury_intoxicants = 6051
+	}
+}
+
+wealth_80 = {
+	political_strength = 117.85
+    goods = {
+		popneed_standard_clothing = 1333
+		popneed_heating = 1333
+		popneed_services = 8019
+		popneed_luxury_drinks = 5347
+		popneed_free_movement = 5285
+		popneed_communication = 6027
+		popneed_luxury_food = 5186
+		popneed_luxury_items = 14618
+		popneed_household_items = 1333
+		popneed_financial_services = 17088
+		popneed_tourism = 15269
+		popneed_media = 18485
+		popneed_luxury_intoxicants = 6695
+	}
+}
+
+wealth_81 = {
+	political_strength = 119.54
+    goods = {
+		popneed_standard_clothing = 1463
+		popneed_heating = 1463
+		popneed_services = 8778
+		popneed_luxury_drinks = 5865
+		popneed_free_movement = 5808
+		popneed_communication = 6546
+		popneed_luxury_food = 5729
+		popneed_luxury_items = 15984
+		popneed_household_items = 1463
+		popneed_financial_services = 18900
+		popneed_tourism = 16906
+		popneed_media = 20309
+		popneed_luxury_intoxicants = 7419
+	}
+}
+
+wealth_82 = {
+	political_strength = 121.24
+    goods = {
+		popneed_standard_clothing = 1610
+		popneed_heating = 1610
+		popneed_services = 9639
+		popneed_luxury_drinks = 6452
+		popneed_free_movement = 6404
+		popneed_communication = 7121
+		popneed_luxury_food = 6354
+		popneed_luxury_items = 17541
+		popneed_household_items = 1610
+		popneed_financial_services = 20951
+		popneed_tourism = 18758
+		popneed_media = 22359
+		popneed_luxury_intoxicants = 8239
+	}
+}
+
+wealth_83 = {
+	political_strength = 122.93
+    goods = {
+		popneed_standard_clothing = 1777
+		popneed_heating = 1777
+		popneed_services = 10622
+		popneed_luxury_drinks = 7123
+		popneed_free_movement = 7089
+		popneed_communication = 7766
+		popneed_luxury_food = 7072
+		popneed_luxury_items = 19334
+		popneed_household_items = 1777
+		popneed_financial_services = 23299
+		popneed_tourism = 20882
+		popneed_media = 24694
+		popneed_luxury_intoxicants = 9179
+	}
+}
+
+wealth_84 = {
+	political_strength = 124.62
+    goods = {
+		popneed_standard_clothing = 1971
+		popneed_heating = 1971
+		popneed_services = 11763
+		popneed_luxury_drinks = 7900
+		popneed_free_movement = 7886
+		popneed_communication = 8503
+		popneed_luxury_food = 7912
+		popneed_luxury_items = 21427
+		popneed_household_items = 1971
+		popneed_financial_services = 26023
+		popneed_tourism = 23345
+		popneed_media = 27389
+		popneed_luxury_intoxicants = 10273
+	}
+}
+
+wealth_85 = {
+	political_strength = 126.31
+    goods = {
+		popneed_standard_clothing = 2199
+		popneed_heating = 2199
+		popneed_services = 13111
+		popneed_luxury_drinks = 8816
+		popneed_free_movement = 8829
+		popneed_communication = 9355
+		popneed_luxury_food = 8904
+		popneed_luxury_items = 23906
+		popneed_household_items = 2199
+		popneed_financial_services = 29234
+		popneed_tourism = 26252
+		popneed_media = 30554
+		popneed_luxury_intoxicants = 11563
+	}
+}
+
+wealth_86 = {
+	political_strength = 128.0
+    goods = {
+		popneed_standard_clothing = 2473
+		popneed_heating = 2473
+		popneed_services = 14731
+		popneed_luxury_drinks = 9915
+		popneed_free_movement = 9964
+		popneed_communication = 10362
+		popneed_luxury_food = 10098
+		popneed_luxury_items = 26894
+		popneed_household_items = 2473
+		popneed_financial_services = 33097
+		popneed_tourism = 29744
+		popneed_media = 34341
+		popneed_luxury_intoxicants = 13114
+	}
+}
+
+wealth_87 = {
+	political_strength = 129.7
+    goods = {
+		popneed_standard_clothing = 2808
+		popneed_heating = 2808
+		popneed_services = 16725
+		popneed_luxury_drinks = 11264
+		popneed_free_movement = 11357
+		popneed_communication = 11584
+		popneed_luxury_food = 11559
+		popneed_luxury_items = 30564
+		popneed_household_items = 2808
+		popneed_financial_services = 37839
+		popneed_tourism = 34037
+		popneed_media = 38976
+		popneed_luxury_intoxicants = 15021
+	}
+}
+
+wealth_88 = {
+	political_strength = 131.39
+    goods = {
+		popneed_standard_clothing = 3228
+		popneed_heating = 3228
+		popneed_services = 19235
+		popneed_luxury_drinks = 12957
+		popneed_free_movement = 13105
+		popneed_communication = 13099
+		popneed_luxury_food = 13386
+		popneed_luxury_items = 35172
+		popneed_household_items = 3228
+		popneed_financial_services = 43800
+		popneed_tourism = 39433
+		popneed_media = 44784
+		popneed_luxury_intoxicants = 17421
+	}
+}
+
+wealth_89 = {
+	political_strength = 133.08
+    goods = {
+		popneed_standard_clothing = 3768
+		popneed_heating = 3768
+		popneed_services = 22471
+		popneed_luxury_drinks = 15135
+		popneed_free_movement = 15350
+		popneed_communication = 15026
+		popneed_luxury_food = 15719
+		popneed_luxury_items = 41084
+		popneed_household_items = 3768
+		popneed_financial_services = 51483
+		popneed_tourism = 46381
+		popneed_media = 52244
+		popneed_luxury_intoxicants = 20516
+	}
+}
+
+wealth_90 = {
+	political_strength = 134.77
+    goods = {
+		popneed_standard_clothing = 4478
+		popneed_heating = 4478
+		popneed_services = 26740
+		popneed_luxury_drinks = 18000
+		popneed_free_movement = 18300
+		popneed_communication = 17534
+		popneed_luxury_food = 18770
+		popneed_luxury_items = 48836
+		popneed_household_items = 4478
+		popneed_financial_services = 61615
+		popneed_tourism = 55557
+		popneed_media = 62054
+		popneed_luxury_intoxicants = 24604
+	}
+}
+
+wealth_91 = {
+	political_strength = 136.46
+    goods = {
+		popneed_standard_clothing = 5431
+		popneed_heating = 5431
+		popneed_services = 32501
+		popneed_luxury_drinks = 21855
+		popneed_free_movement = 22252
+		popneed_communication = 20872
+		popneed_luxury_food = 22833
+		popneed_luxury_items = 59212
+		popneed_household_items = 5431
+		popneed_financial_services = 75294
+		popneed_tourism = 67940
+		popneed_media = 75239
+		popneed_luxury_intoxicants = 30122
+	}
+}
+
+wealth_92 = {
+	political_strength = 138.16
+    goods = {
+		popneed_standard_clothing = 6738
+		popneed_heating = 6738
+		popneed_services = 40437
+		popneed_luxury_drinks = 27155
+		popneed_free_movement = 27654
+		popneed_communication = 25390
+		popneed_luxury_food = 28348
+		popneed_luxury_items = 73347
+		popneed_household_items = 6738
+		popneed_financial_services = 94134
+		popneed_tourism = 84997
+		popneed_media = 93326
+		popneed_luxury_intoxicants = 37735
+	}
+}
+
+wealth_93 = {
+	political_strength = 139.85
+    goods = {
+		popneed_standard_clothing = 8560
+		popneed_heating = 8560
+		popneed_services = 51540
+		popneed_luxury_drinks = 34548
+		popneed_free_movement = 35156
+		popneed_communication = 31595
+		popneed_luxury_food = 35944
+		popneed_luxury_items = 92894
+		popneed_household_items = 8560
+		popneed_financial_services = 120551
+		popneed_tourism = 108935
+		popneed_media = 118565
+		popneed_luxury_intoxicants = 48424
+	}
+}
+
+wealth_94 = {
+	political_strength = 141.54
+    goods = {
+		popneed_standard_clothing = 11135
+		popneed_heating = 11135
+		popneed_services = 67335
+		popneed_luxury_drinks = 45042
+		popneed_free_movement = 45721
+		popneed_communication = 40243
+		popneed_luxury_food = 46534
+		popneed_luxury_items = 120238
+		popneed_household_items = 11135
+		popneed_financial_services = 158176
+		popneed_tourism = 143032
+		popneed_media = 154312
+		popneed_luxury_intoxicants = 63660
+	}
+}
+
+wealth_95 = {
+	political_strength = 143.23
+    goods = {
+		popneed_standard_clothing = 14817
+		popneed_heating = 14817
+		popneed_services = 90074
+		popneed_luxury_drinks = 60084
+		popneed_free_movement = 60721
+		popneed_communication = 52379
+		popneed_luxury_food = 61388
+		popneed_luxury_items = 158796
+		popneed_household_items = 14817
+		popneed_financial_services = 212450
+		popneed_tourism = 192224
+		popneed_media = 205530
+		popneed_luxury_intoxicants = 85673
+	}
+}
+
+wealth_96 = {
+	political_strength = 144.92
+    goods = {
+		popneed_standard_clothing = 20130
+		popneed_heating = 20130
+		popneed_services = 123093
+		popneed_luxury_drinks = 81847
+		popneed_free_movement = 82169
+		popneed_communication = 69548
+		popneed_luxury_food = 82310
+		popneed_luxury_items = 213435
+		popneed_household_items = 20130
+		popneed_financial_services = 291457
+		popneed_tourism = 263859
+		popneed_media = 279601
+		popneed_luxury_intoxicants = 117779
+	}
+}
+
+wealth_97 = {
+	political_strength = 146.62
+    goods = {
+		popneed_standard_clothing = 27848
+		popneed_heating = 27848
+		popneed_services = 171463
+		popneed_luxury_drinks = 113622
+		popneed_free_movement = 112953
+		popneed_communication = 93933
+		popneed_luxury_food = 111812
+		popneed_luxury_items = 290989
+		popneed_household_items = 27848
+		popneed_financial_services = 407451
+		popneed_tourism = 369104
+		popneed_media = 387512
+		popneed_luxury_intoxicants = 164974
+	}
+}
+
+wealth_98 = {
+	political_strength = 148.31
+    goods = {
+		popneed_standard_clothing = 39124
+		popneed_heating = 39124
+		popneed_services = 242806
+		popneed_luxury_drinks = 160293
+		popneed_free_movement = 157280
+		popneed_communication = 128759
+		popneed_luxury_food = 153251
+		popneed_luxury_items = 400987
+		popneed_household_items = 39124
+		popneed_financial_services = 579003
+		popneed_tourism = 524816
+		popneed_media = 545865
+		popneed_luxury_intoxicants = 234903
+	}
+}
+
+wealth_99 = {
+	political_strength = 150.0
+    goods = {
+		popneed_standard_clothing = 55664
+		popneed_heating = 55664
+		popneed_services = 348682
+		popneed_luxury_drinks = 229170
+		popneed_free_movement = 221099
+		popneed_communication = 178571
+		popneed_luxury_food = 211135
+		popneed_luxury_items = 556365
+		popneed_household_items = 55664
+		popneed_financial_services = 834075
+		popneed_tourism = 756423
+		popneed_media = 779357
+		popneed_luxury_intoxicants = 339107
+	}
+}


### PR DESCRIPTION
Housing and healthcare pop needs removed from the buy packages.

Currently in the middle of ordering the pop needs for each wealth in alphabetical order, but that is an ongoing WIP.