### PR TITLE
feat: restore diplomatic history

### DIFF
--- a/.metadata/metadata.json
+++ b/.metadata/metadata.json
@@ -19,8 +19,6 @@
       "common/customizable_localization",
       "common/decisions",
       "common/decrees",
-      "common/diplomatic_actions",
-      "common/diplomatic_catalysts",
       "common/diplomatic_plays",
       "common/dynamic_country_map_colors",
       "common/dynamic_country_names",
@@ -61,7 +59,6 @@
       "common/scripted_effects",
       "common/scripted_progress_bars",
       "common/technology",
-      "common/treaty_articles",
 
       "events",
       "events/agitators_events",

--- a/common/history/diplomacy/00_defensive_pacts.txt
+++ b/common/history/diplomacy/00_defensive_pacts.txt
@@ -1,0 +1,36 @@
+﻿DIPLOMACY = {
+	c:USA = {
+		create_diplomatic_pact = {
+			country = c:CAN
+			type = alliance
+		}
+	}
+	c:GBR = {
+		create_diplomatic_pact = {
+			country = c:FRA
+			type = alliance
+		}
+	}
+	c:BEL = {
+		create_diplomatic_pact = {
+			country = c:NET
+			type = alliance
+		}
+		create_diplomatic_pact = {
+			country = c:LUX
+			type = alliance
+		}
+	}
+	c:NET = {
+		create_diplomatic_pact = {
+			country = c:LUX
+			type = alliance
+		}
+	}
+	c:AZR = {
+		create_diplomatic_pact = {
+			country = c:KUR
+			type = alliance
+		}
+	}
+}

--- a/common/history/diplomacy/00_favors.txt
+++ b/common/history/diplomacy/00_favors.txt
@@ -1,0 +1,1 @@
+﻿#This file is intentionally blank to remove contents of basegame file

--- a/common/history/diplomacy/00_relations.txt
+++ b/common/history/diplomacy/00_relations.txt
@@ -1,0 +1,149 @@
+﻿DIPLOMACY = {
+	c:GBR = {
+		set_relations = { country = c:CAN value = 80 }
+		set_relations = { country = c:USA value = 100 }
+		set_relations = { country = c:FRA value = 100 }
+		set_relations = { country = c:AST value = 80 }
+		set_relations = { country = c:NZL value = 80 }
+		set_relations = { country = c:ARG value = -10 }
+		set_relations = { country = c:POR value = 100 }
+	}
+	c:USA = {
+		set_relations = { country = c:CAN value = 100 }
+		set_relations = { country = c:GBR value = 100 }
+		set_relations = { country = c:FRA value = 80 }
+		set_relations = { country = c:AST value = 80 }
+		set_relations = { country = c:NZL value = 80 }
+		set_relations = { country = c:MEX value = 80 }
+		set_relations = { country = c:CUB value = 80 }
+		set_relations = { country = c:MOR value = 50 }
+	}
+	c:BEL = {
+		set_relations = { country = c:LUX value = 100 }
+		set_relations = { country = c:NET value = 100 }
+		set_relations = { country = c:CAN value = 30 }
+		set_relations = { country = c:USA value = 30 }
+		set_relations = { country = c:FRA value = 30 }
+		set_relations = { country = c:AST value = 30 }
+		set_relations = { country = c:NZL value = 30 }
+	}
+	c:NET = {
+		set_relations = { country = c:BEL value = 100 }
+		set_relations = { country = c:LUX value = 100 }
+		set_relations = { country = c:CAN value = 30 }
+		set_relations = { country = c:USA value = 30 }
+		set_relations = { country = c:FRA value = 30 }
+		set_relations = { country = c:AST value = 30 }
+		set_relations = { country = c:NZL value = 30 }
+	}
+	c:LUX = {
+		set_relations = { country = c:BEL value = 100 }
+		set_relations = { country = c:NET value = 100 }
+		set_relations = { country = c:CAN value = 30 }
+		set_relations = { country = c:USA value = 30 }
+		set_relations = { country = c:FRA value = 30 }
+		set_relations = { country = c:AST value = 30 }
+		set_relations = { country = c:NZL value = 30 }
+	}
+	c:CAN = {
+		set_relations = { country = c:USA value = 100 }
+		set_relations = { country = c:GBR value = 80 }
+		set_relations = { country = c:FRA value = 80 }
+		set_relations = { country = c:AST value = 80 }
+		set_relations = { country = c:NZL value = 80 }
+	}
+	c:FRA = {
+		set_relations = { country = c:CAN value = 80 }
+		set_relations = { country = c:GBR value = 100 }
+		set_relations = { country = c:USA value = 80 }
+		set_relations = { country = c:AST value = 80 }
+		set_relations = { country = c:NZL value = 80 }
+	}
+	c:AST = {
+		set_relations = { country = c:CAN value = 80 }
+		set_relations = { country = c:GBR value = 80 }
+		set_relations = { country = c:FRA value = 80 }
+		set_relations = { country = c:USA value = 80 }
+		set_relations = { country = c:NZL value = 100 }
+	}
+	c:NZL = {
+		set_relations = { country = c:CAN value = 80 }
+		set_relations = { country = c:GBR value = 80 }
+		set_relations = { country = c:FRA value = 80 }
+		set_relations = { country = c:AST value = 100 }
+		set_relations = { country = c:USA value = 80 }
+	}
+	c:RUS = {
+		set_relations = { country = c:CAN value = -30 }
+		set_relations = { country = c:GBR value = -30 }
+		set_relations = { country = c:FRA value = -30 }
+		set_relations = { country = c:AST value = -30 }
+		set_relations = { country = c:USA value = -80 }
+		set_relations = { country = c:NZL value = -30 }
+	}
+	c:ARG = {
+		set_relations = { country = c:GBR value = -50 }
+		set_relations = { country = c:CHL value = -80 }
+	}
+	c:IDS = {
+		set_relations = { country = c:NET value = -100 }
+	}
+	c:PRC = {
+		set_relations = { country = c:ROC value = -100 }
+		set_relations = { country = c:JAP value = -80 }
+	}
+	c:ROC = {
+		set_relations = { country = c:PRC value = -100 }
+		set_relations = { country = c:JAP value = -80 }
+	}
+	c:STK = {
+		set_relations = { country = c:JAP value = -80 }
+		set_relations = { country = c:NRK value = -80 }
+		set_relations = { country = c:USA value = 20 }
+	}
+	c:NRK = {
+		set_relations = { country = c:JAP value = -80 }
+		set_relations = { country = c:STK value = -20 }
+		set_relations = { country = c:RUS value = 20 }
+	}
+	c:PEU = {
+		set_relations = { country = c:ECU value = -50 }
+	}
+	c:ECU = {
+		set_relations = { country = c:PEU value = -50 }
+	}
+	c:PER = {
+		set_relations = { country = c:GBR value = -50 }
+		set_relations = { country = c:RUS value = -50 }
+	}
+	c:EGY = {
+		set_relations = { country = c:SYR value = 80 }
+		set_relations = { country = c:EOT value = 50 }
+		set_relations = { country = c:IRQ value = 50 }
+		set_relations = { country = c:GBR value = 50 }
+
+	}
+	c:SYR = {
+		set_relations = { country = c:EGY value = 80 }
+		set_relations = { country = c:EOT value = 50 }
+		set_relations = { country = c:IRQ value = 50 }
+	}
+	c:IRQ = {
+		set_relations = { country = c:SYR value = 50 }
+		set_relations = { country = c:EOT value = 80 }
+		set_relations = { country = c:EGY value = 50 }
+		set_relations = { country = c:GBR value = 50 }
+	}
+	c:EOT = {
+		set_relations = { country = c:SYR value = 50 }
+		set_relations = { country = c:EGY value = 50 }
+		set_relations = { country = c:IRQ value = 80 }
+		set_relations = { country = c:GBR value = 50 }
+	}
+	c:MOR = {
+		set_relations = { country = c:USA value = 50 }
+	}
+	c:AZR = {
+		set_relations = { country = c:KUR value = 30 }
+	}
+}

--- a/common/history/diplomacy/00_rivalries.txt
+++ b/common/history/diplomacy/00_rivalries.txt
@@ -1,0 +1,15 @@
+﻿DIPLOMACY = {
+	c:USA = {
+		create_diplomatic_pact = {
+			country = c:RUS
+			type = rivalry
+		}
+	}	
+
+	c:RUS = {
+		create_diplomatic_pact = {
+			country = c:USA
+			type = rivalry
+		}
+	}
+}

--- a/common/history/diplomacy/00_subject_relationships.txt
+++ b/common/history/diplomacy/00_subject_relationships.txt
@@ -1,0 +1,467 @@
+﻿DIPLOMACY = {
+	c:GBR = {
+		create_diplomatic_pact = {
+			country = c:SRI
+			type = puppet
+		}
+		create_diplomatic_pact = {
+			country = c:CYP
+			type = puppet
+		}
+		create_diplomatic_pact = {
+			country = c:BOZ
+			type = military_occupation
+		}
+		create_diplomatic_pact = {
+			country = c:BOZ
+			type = grant_own_market
+		}
+		create_diplomatic_pact = {
+			country = c:HND
+			type = puppet
+		}
+		create_diplomatic_pact = {
+			country = c:GAM
+			type = puppet
+		}
+		create_diplomatic_pact = {
+			country = c:SIL
+			type = puppet
+		}
+		create_diplomatic_pact = {
+			country = c:GLC
+			type = puppet
+		}
+		create_diplomatic_pact = {
+			country = c:SOK
+			type = puppet
+		}
+		create_diplomatic_pact = {
+			country = c:ESW
+			type = puppet
+		}
+		create_diplomatic_pact = {
+			country = c:BST
+			type = puppet
+		}
+		create_diplomatic_pact = {
+			country = c:TSW
+			type = puppet
+		}
+		create_diplomatic_pact = {
+			country = c:MTB
+			type = puppet
+		}
+		create_diplomatic_pact = {
+			country = c:LZO
+			type = puppet
+		}
+		create_diplomatic_pact = {
+			country = c:BMB
+			type = puppet
+		}
+		create_diplomatic_pact = {
+			country = c:TNZ
+			type = puppet
+		}
+		create_diplomatic_pact = {
+			country = c:BUG
+			type = puppet
+		}
+		create_diplomatic_pact = {
+			country = c:KKY
+			type = puppet
+		}
+		create_diplomatic_pact = {
+			country = c:SML
+			type = military_occupation
+		}
+		create_diplomatic_pact = {
+			country = c:SML
+			type = grant_own_market
+		}
+		create_diplomatic_pact = {
+			country = c:SLL
+			type = protectorate
+		}
+		create_diplomatic_pact = {
+			country = c:ZZB
+			type = protectorate
+		}
+		create_diplomatic_pact = {
+			country = c:ERI
+			type = military_occupation
+		}
+		create_diplomatic_pact = {
+			country = c:ERI
+			type = grant_own_market
+		}
+		create_diplomatic_pact = {
+			country = c:SDN
+			type = puppet
+		}
+		create_diplomatic_pact = {
+			country = c:LBY
+			type = military_occupation
+		}
+		create_diplomatic_pact = {
+			country = c:LBY
+			type = grant_own_market
+		}
+		create_diplomatic_pact = {
+			country = c:ABU
+			type = puppet
+		}
+		create_diplomatic_pact = {
+			country = c:QAT
+			type = protectorate
+		}
+		create_diplomatic_pact = {
+			country = c:BHN
+			type = puppet
+		}
+		create_diplomatic_pact = {
+			country = c:KUW
+			type = puppet
+		}
+		create_diplomatic_pact = {
+			country = c:PAL
+			type = protectorate
+		}
+		create_diplomatic_pact = {
+			country = c:EOT
+			type = protectorate
+		}
+		create_diplomatic_pact = {
+			country = c:CYP
+			type = dominion
+		}
+		create_diplomatic_pact = {
+			country = c:MYM
+			type = puppet
+		}
+		create_diplomatic_pact = {
+			country = c:MYY
+			type = puppet
+		}
+		create_diplomatic_pact = {
+			country = c:SGP
+			type = puppet
+		}
+		create_diplomatic_pact = {
+			country = c:ADE
+			type = protectorate
+		}
+		create_diplomatic_pact = {
+			country = c:HKN
+			type = puppet
+		}
+		create_diplomatic_pact = {
+			country = c:NEW			# Until 1949
+			type = puppet
+		}
+		# Dominions
+		create_diplomatic_pact = {
+			country = c:CAN			# Until 1982
+			type = dominion
+		}
+		create_diplomatic_pact = {
+			country = c:AST			# Until 1986
+			type = dominion
+		}
+		create_diplomatic_pact = {
+			country = c:SAF			# Until 1961
+			type = dominion
+		}
+		create_diplomatic_pact = {
+			country = c:NZL			# Until 1986
+			type = dominion
+		}
+		create_diplomatic_pact = {
+			country = c:NZL			# Until 1986
+			type = dominion
+		}
+		create_diplomatic_pact = {
+			country = c:IRQ
+			type = dominion
+		}
+		create_diplomatic_pact = {
+			country = c:MLT
+			type = puppet
+		}
+	}
+	c:DEN = {
+		create_diplomatic_pact = {
+			country = c:GRN
+			type = puppet
+		}
+	}
+	c:NOR = {
+	}
+	c:FRA = {
+		create_diplomatic_pact = {
+			country = c:FOZ
+			type = military_occupation
+		}
+		create_diplomatic_pact = {
+			country = c:FOZ
+			type = grant_own_market
+		}
+		create_diplomatic_pact = {
+			country = c:SYR
+			type = military_occupation
+		}
+		create_diplomatic_pact = {
+			country = c:SYR
+			type = grant_own_market
+		}
+		create_diplomatic_pact = {
+			country = c:FEZ
+			type = military_occupation
+		}
+		create_diplomatic_pact = {
+			country = c:FEZ
+			type = grant_own_market
+		}
+		create_diplomatic_pact = {
+			country = c:TUN
+			type = puppet
+		}
+		create_diplomatic_pact = {
+			country = c:MOR
+			type = puppet
+		}
+		create_diplomatic_pact = {
+			country = c:EWE
+			type = puppet
+		}
+		#TODO: West African Federation breaks apart
+		create_diplomatic_pact = {
+			country = c:WAU
+			type = puppet
+		}
+		create_diplomatic_pact = {
+			country = c:MGS
+			type = puppet
+		}
+		create_diplomatic_pact = {
+			country = c:DLA
+			type = puppet
+		}
+		create_diplomatic_pact = {
+			country = c:EQA
+			type = puppet
+		}
+		create_diplomatic_pact = {
+			country = c:DJI
+			type = puppet
+		}
+		create_diplomatic_pact = {
+			country = c:VNM
+			type = puppet
+		}
+	}
+	c:NET = {
+		create_diplomatic_pact = {
+			country = c:WPP
+			type = puppet
+		}
+		create_diplomatic_pact = {
+			country = c:IDS
+			type = puppet
+		}
+	}
+	c:USA = {
+		create_diplomatic_pact = {
+			country = c:AOZ
+			type = military_occupation
+		}
+		create_diplomatic_pact = {
+			country = c:AOZ
+			type = grant_own_market
+		}
+		create_diplomatic_pact = {
+			country = c:PHI
+			type = puppet
+		}
+		create_diplomatic_pact = {
+			country = c:JAP
+			type = military_occupation
+		}
+		create_diplomatic_pact = {
+			country = c:JAP
+			type = grant_own_market
+		}
+		create_diplomatic_pact = {
+			country = c:STK
+			type = military_occupation
+		}
+		create_diplomatic_pact = {
+			country = c:STK
+			type = grant_own_market
+		}
+	}
+	c:RUS = {
+		create_diplomatic_pact = {
+			country = c:ROM
+			type = military_occupation
+		}
+		create_diplomatic_pact = {
+			country = c:ROM
+			type = grant_own_market
+		}
+		create_diplomatic_pact = {
+			country = c:POL
+			type = military_occupation
+		}
+		create_diplomatic_pact = {
+			country = c:POL
+			type = grant_own_market
+		}
+		create_diplomatic_pact = {
+			country = c:BUL
+			type = military_occupation
+		}
+		create_diplomatic_pact = {
+			country = c:BUL
+			type = grant_own_market
+		}
+		create_diplomatic_pact = {
+			country = c:HUN
+			type = military_occupation
+		}
+		create_diplomatic_pact = {
+			country = c:HUN
+			type = grant_own_market
+		}
+		create_diplomatic_pact = {
+			country = c:ALB
+			type = military_occupation
+		}
+		create_diplomatic_pact = {
+			country = c:ALB
+			type = grant_own_market
+		}
+		create_diplomatic_pact = {
+			country = c:CZH
+			type = military_occupation
+		}
+		create_diplomatic_pact = {
+			country = c:CZH
+			type = grant_own_market
+		}
+		create_diplomatic_pact = {
+			country = c:DDR
+			type = military_occupation
+		}
+		create_diplomatic_pact = {
+			country = c:DDR
+			type = grant_own_market
+		}
+		create_diplomatic_pact = {
+			country = c:AUS
+			type = military_occupation
+		}
+		create_diplomatic_pact = {
+			country = c:AUS
+			type = grant_own_market
+		}
+		create_diplomatic_pact = {
+			country = c:MGL
+			type = puppet
+		}
+		create_diplomatic_pact = {
+			country = c:NRK
+			type = military_occupation
+		}
+		create_diplomatic_pact = {
+			country = c:NRK
+			type = grant_own_market
+		}
+		#todo: revisit when proxy war mechanic
+		#create_diplomatic_pact = {
+		#	country = c:AZR
+		#	type = dominion
+		#}
+		#create_diplomatic_pact = {
+		#	country = c:KUR
+		#	type = dominion
+		#}
+	}
+	c:BEL = {
+		create_diplomatic_pact = {
+			country = c:CNG
+			type = puppet
+		}
+		create_diplomatic_pact = {
+			country = c:RWD
+			type = puppet
+		}
+	}
+	c:POR = {
+		create_diplomatic_pact = {
+			country = c:MAO
+			type = puppet
+		}
+		create_diplomatic_pact = {
+			country = c:OVM
+			type = puppet
+		}
+		create_diplomatic_pact = {
+			country = c:GNB
+			type = puppet
+		}
+		create_diplomatic_pact = {
+			country = c:MKU
+			type = puppet
+		}
+	}
+	c:AST = {
+		create_diplomatic_pact = {
+			country = c:PPN
+			type = puppet
+		}
+	}
+	# c:NZL = {
+	#TODO these countries no longer exist in game? needs to be fixed
+	# create_diplomatic_pact = {
+	# 	country = c:NIU
+	# 	type = puppet
+	# }
+	# create_diplomatic_pact = {
+	# 	country = c:SMO
+	# 	type = puppet
+	# }
+	# create_diplomatic_pact = {
+	# 	country = c:COO
+	# 	type = puppet
+	# }
+	# create_diplomatic_pact = {
+	# 	country = c:TKL
+	# 	type = puppet
+	# }
+	# }
+	c:ROC = {
+		create_diplomatic_pact = {
+			country = c:TIB
+			type = puppet
+		}
+	}
+	#South Africa and Namibia
+	c:SAF = {
+		create_diplomatic_pact = {
+			country = c:NAM
+			type = puppet
+		}
+	}
+	c:HND = {
+		create_diplomatic_pact = {
+			country = c:NEP
+			type = tributary
+		}
+		create_diplomatic_pact = {
+			country = c:BHU
+			type = vassal
+		}
+	}
+}

--- a/common/history/diplomacy/00_trade_agreement.txt
+++ b/common/history/diplomacy/00_trade_agreement.txt
@@ -1,0 +1,1 @@
+﻿#This file is intentionally blank to remove contents of basegame file

--- a/common/history/diplomacy/00_truces.txt
+++ b/common/history/diplomacy/00_truces.txt
@@ -1,0 +1,1 @@
+﻿#This file is intentionally blank to remove contents of basegame file

--- a/common/history/diplomatic_plays/chinese_civil_war.txt
+++ b/common/history/diplomatic_plays/chinese_civil_war.txt
@@ -1,0 +1,10 @@
+﻿DIPLOMATIC_PLAYS = {
+	c:PRC ?= {
+		create_diplomatic_play = {
+			name = chinese_civil_war
+			target_state = s:STATE_NANJING.region_state:ROC
+			escalation = 80
+			type = dp_revolution
+		}
+	}
+}

--- a/common/history/diplomatic_plays/indonesia_rebellion.txt
+++ b/common/history/diplomatic_plays/indonesia_rebellion.txt
@@ -1,0 +1,11 @@
+﻿DIPLOMATIC_PLAYS = {
+	# Need to revisit this later
+	c:IDS ?= {
+		create_diplomatic_play = {
+			name = indonesian_revolution
+			target_country = c:NET
+			war = yes
+			type = dp_independence
+		}
+	}
+}

--- a/common/history/diplomatic_plays/kurdish_azerbaijani_breakaway.txt
+++ b/common/history/diplomatic_plays/kurdish_azerbaijani_breakaway.txt
@@ -1,0 +1,28 @@
+﻿DIPLOMATIC_PLAYS = {
+	c:PER ?= {
+		create_diplomatic_play = {
+			name = azerbaijani_revolution
+			target_state = s:STATE_TABRIZ.region_state:AZR
+			war = yes
+			type = dp_return_state
+			add_war_goal = {
+				holder = c:AZR
+				target_country = c:PER
+				type = revoke_all_claims
+			}
+		}
+	}
+	c:PER ?= {
+		create_diplomatic_play = {
+			name = kurdish_revolution
+			target_state = s:STATE_TABRIZ.region_state:KUR
+			war = yes
+			type = dp_return_state
+			add_war_goal = {
+				holder = c:KUR
+				target_country = c:PER
+				type = revoke_all_claims
+			}
+		}
+	}
+}


### PR DESCRIPTION
- Restore diplomatic actions, diplomatic plays, and treaty system
- Restore diplomatic history

This does not restore any diplomatic history that must be represented by treaties as introduced in 1.9.