### PR TITLE
Alcohol allowed in Italy

### DIFF
--- a/common/history/countries/ita - italy.txt
+++ b/common/history/countries/ita - italy.txt
@@ -30,6 +30,7 @@
 		activate_law = law_type:law_unrestricted_human_testing
 		activate_law = law_type:law_penal_correction
 		activate_law = law_type:law_no_nationalization
+		activate_law = law_type:law_alcohol_allowed
 		set_imf_member = yes
 		set_imf_starting_values = {
 			debtValue = 4430455


### PR DESCRIPTION
Italy in 1946 dind't have proibition, alcohol and tobacco were already quite established industries.
Just a little thing I wanted to fix while playing lol