### PR TITLE
fix: fix production tech tree

### DIFF
--- a/common/technology/technologies/10_production.txt
+++ b/common/technology/technologies/10_production.txt
@@ -187,7 +187,7 @@ vacuum_tubes = {
 	}
 }
 
-advanced_chemical_synthesis = {
+chemical_synthesis = {
 	era = era_1
 	texture = "gfx/interface/icons/invention_icons/invention_placeholder.dds"
 	category = production
@@ -339,7 +339,7 @@ intensive_fertilizer = {
     modifier = {
 	}
 	unlocking_technologies = {
-		advanced_chemical_synthesis
+		chemical_synthesis
 	}
 	ai_weight = {
 		value = 1
@@ -353,7 +353,7 @@ chemical_batteries = {
     modifier = {
 	}
 	unlocking_technologies = {
-		advanced_chemical_synthesis
+		chemical_synthesis
 	}
 	ai_weight = {
 		value = 1
@@ -367,7 +367,7 @@ polyester = {
     modifier = {
 	}
 	unlocking_technologies = {
-		advanced_chemical_synthesis
+		chemical_synthesis
 	}
 	ai_weight = {
 		value = 1
@@ -381,7 +381,7 @@ industrial_kraft_pulping = {
     modifier = {
 	}
 	unlocking_technologies = {
-		advanced_chemical_synthesis
+		chemical_synthesis
 	}
 	ai_weight = {
 		value = 1
@@ -395,7 +395,7 @@ silicone_rubber = {
     modifier = {
 	}
 	unlocking_technologies = {
-		advanced_chemical_synthesis
+		chemical_synthesis
 	}
 	ai_weight = {
 		value = 1
@@ -409,7 +409,7 @@ inorganic_synthesis = {
     modifier = {
 	}
 	unlocking_technologies = {
-		advanced_chemical_synthesis
+		chemical_synthesis
 	}
 	ai_weight = {
 		value = 1


### PR DESCRIPTION
We had two `advanced_chemical_synthesis` prior to this change. This changes the one in the first era to simply `chemical_synthesis`.