### PR TITLE
fix: fix usa name

### DIFF
--- a/common/scripted_triggers/cwp_coa_triggers.txt
+++ b/common/scripted_triggers/cwp_coa_triggers.txt
@@ -15,7 +15,7 @@ coa_executive_flag_trigger = {
 }
 
 coa_corporatist_trigger = {
-	has_government_type = gov_corporate_state
+	has_law_or_variant = law_type:law_corporate_state
 }
 
 coa_controls_part_of_greater_rhineland = {


### PR DESCRIPTION
Fixes the dynamic names for corporate states such that USA is no longer erroneously named incorrectly.